### PR TITLE
add basic setup and directory structure

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,57 @@
+[metadata]
+name = uwtools
+version = 0.0.1
+description = Unified Workflow tools for use with applications with UFS and beyond
+long_description = file: README.md
+long_description_content_type = text/markdown
+author = "NOAA, EPIC"
+#author_email = first.last@domain.tld
+keywords = NOAA, EPIC, UFS
+home_page = https://github.com/ufs-community/workflow-tools
+license = GNU Lesser General Public License
+classifiers =
+    Development Status :: 1 - Beta
+    Intended Audience :: Developers
+    Intended Audience :: Science/Research
+    License :: OSI Approved :: GNU Lesser General Public License
+    Natural Language :: English
+    Operating System :: OS Independent
+    Programming Language :: Python
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Topic :: Software Development :: Libraries :: Python Modules
+    Operating System :: OS Independent
+    Typing :: Typed
+project_urls =
+    Bug Tracker = https://github.com/noaa-emc/emcpy/issues
+    CI = https://github.com/noaa-emc/emcpy/actions
+
+[options]
+zip_safe = False
+include_package_data = True
+package_dir =
+  =src
+packages = find_namespace:
+python_requires = >= 3.6
+setup_requires =
+  setuptools
+install_requires =
+  pylint
+tests_require =
+  pytest
+
+[options.packages.find]
+where=src
+
+[options.package_data]
+* = *.txt, *.md
+
+[green]
+file-pattern = test_*.py
+verbose = 2
+no-skip-report = true
+quiet-stdout = true
+run-coverage = true

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,2 @@
+import setuptools
+setuptools.setup()

--- a/src/uwtools/__init__.py
+++ b/src/uwtools/__init__.py
@@ -1,0 +1,5 @@
+__docformat__ = "NumPy/SciPy"
+
+import os
+
+uwtools_directory = os.path.dirname(__file__)


### PR DESCRIPTION
This PR:
- adds a very basic `setup.py` and `setup.cfg` skeleton
- adds a very basic directory structure for source code and tests and possibly documentation (when it arrives)

Note:
The `src/tests/.gitignore` file will disappear when we add tests.  It is simply added to create an empty `tests` directory and `git` does not allow adding empty directories.

You can test this very quickly by doing the following:
```
git clone https://github.com/ufs-community/workflow-tools -b feature/setup

python3 -m venv testvenv
source testvenv/bin/activate

cd workflow-tools
pip install .

pip list

python3
import uwtools
help(uwtools)
```