### PR TITLE
Updated link to documentation in README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,4 +12,4 @@ $> pip install .
 ## Documentation
 The inline-documentation docstring standard (using the [NumPy](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard) convention) will be used to describe modules, funtions, classes and methods for inline code documentation.
 
-Documentation is automatically generated when [develop](https://github.com/ufs-community/workflow-tools/tree/develop) is updated and available [here](https://ufs-community.github.io/workflow-tools/).
+Documentation is automatically generated through [Read the Docs](https://readthedocs.org/) when [develop](https://github.com/ufs-community/workflow-tools/tree/develop) is updated and available [here](https://unified-workflow.readthedocs.io/en/latest/).


### PR DESCRIPTION
**Description**
Updated the README.md file to add a link to Read the Docs and an updated link to the United Workflow Documentation as described in [GitHub Issue #14](https://github.com/ufs-community/workflow-tools/issues/14).

**Type of change**
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change is a documentation update

**How Has This Been Tested?**
Compared differences in README.md file and checked links:
[Develop README.md](https://github.com/ufs-community/workflow-tools/blob/develop/README.md)
[Feature Branch README.md](https://github.com/ufs-community/workflow-tools/tree/feature/GHissue_1_README_update)

**Checklist**
- [N/A] My code follows the style guidelines of this project
- [N/A] I have performed a self-review of my own code
- [N/A] I have commented my code, particularly in hard-to-understand areas
- [x] My changes need updates to the documentation.  I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [N/A] Any dependent changes have been merged and published

