### PR TITLE
run pylint recursively in github actions

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,6 @@
+bumpversion]
+current_version = 0.0.1
+commit = True
+tag = True
+
+[bumpversion:file:setup.py]

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,38 @@
+# https://editorconfig.org/
+
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+insert_final_newline = true
+trim_trailing_whitespace = true
+end_of_line = lf
+charset = utf-8
+
+# Docstrings and comments use max_line_length = 79
+[*.py]
+max_line_length = 88
+
+# Use 2 spaces for the HTML files
+[*.html]
+indent_size = 2
+
+# The JSON files contain newlines inconsistently
+[*.json]
+indent_size = 2
+insert_final_newline = ignore
+
+# Makefiles always use tabs for indentation
+[Makefile]
+indent_style = tab
+
+# Batch files use tabs for indentation
+[*.bat]
+indent_style = tab
+
+[docs/**.txt]
+max_line_length = 79
+
+[*.yml]
+indent_size = 2

--- a/.github/workflows/CodeQC.yaml
+++ b/.github/workflows/CodeQC.yaml
@@ -6,19 +6,19 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-    
-    - name: Set up Python 3.8
-      uses: actions/setup-python@v1
-      with:
-        python-version: 3.8
-    
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install pylint
-    
-    - name: Analysing the code with pylint
-      run: |
-        pylint *.py;
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.8
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pylint
+
+      - name: Analysing the code with pylint
+        run: |
+          find . -type f -not -path "./venv/*" -name "*.py" | xargs pylint

--- a/.pylintrc
+++ b/.pylintrc
@@ -113,7 +113,7 @@ never-returning-functions=sys.exit
 additional-builtins=
 
 # Tells whether unused global variables should be treated as a violation.
-allow-global-unused-variables=no
+allow-global-unused-variables=yes
 
 # List of strings which can identify a callback function by name. A callback
 # name must start or end with one of those strings.

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "python.linting.flake8Enabled": false,
+    "python.linting.pylintEnabled": true,
+    "python.linting.enabled": true
+}

--- a/README.md
+++ b/README.md
@@ -13,3 +13,16 @@ $> pip install .
 The inline-documentation docstring standard (using the [NumPy](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard) convention) will be used to describe modules, funtions, classes and methods for inline code documentation.
 
 Documentation is automatically generated through [Read the Docs](https://readthedocs.org/) when [develop](https://github.com/ufs-community/workflow-tools/tree/develop) is updated and available [here](https://unified-workflow.readthedocs.io/en/latest/).
+
+## Running Tests
+Standard tests
+`python -m pytest`
+
+With coverage
+`python -m pytest --cov=src`
+
+With coverage report in html
+`python -m pytest --cov=src --cov-report html`
+
+Run python server to view html test report
+`python -m http.server`

--- a/hello_world.py
+++ b/hello_world.py
@@ -1,3 +1,0 @@
-"""Print module."""
-print("Hello Word")
-print("Good Bye World!!!")

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,60 @@
-''' Standard file for building the package with Distutils. '''
 
-import setuptools
-setuptools.setup()
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# pylint: disable=missing-module-docstring
+
+import os
+import sys
+import codecs
+import subprocess
+
+from setuptools import setup
+
+here = os.path.abspath(os.path.dirname(__file__))
+
+with codecs.open(os.path.join(here, "README.md"), encoding="utf-8") as f:
+    long_description = "\n" + f.read()
+
+
+if sys.argv[-1] == "publish":
+    subprocess.call(f"{sys.executable} setup.py sdist bdist_wheel upload", shell=False)
+    sys.exit()
+
+required = [""]
+
+setup(
+    name="owtools",
+    version="0.0.0",
+    description="Unified workflow tools",
+    long_description=long_description,
+    long_description_content_type="text/x-rst",
+    url="",
+    py_modules=[""],
+    install_requires=required,
+    tests_require=["pytest"],
+    license="MIT",
+    classifiers=[
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+    ],
+    extras_require={  # Optional
+        "dev": [
+            "check-manifest",
+            "black",
+            "pylint",
+            "pytest",
+            "pytest-cov",
+            "pytest-xdist",
+            "tox",
+            "bump2version",
+        ],
+        "test": ["pytest", "pytest-cov", "pytest-forked", "pytest-xdist", "tox"],
+    },
+)

--- a/src/tests/test_dummy.py
+++ b/src/tests/test_dummy.py
@@ -1,7 +1,0 @@
-''' A placeholder test to ensure pytest auto-test is working as
-expected. '''
-
-# pylint: disable=unused-variable
-def test_dummy():
-    ''' Skip the test. Used only as a placeholder. '''
-    return True

--- a/src/uwtools/scheduler.py
+++ b/src/uwtools/scheduler.py
@@ -1,0 +1,117 @@
+"""
+Job Scheduling
+author: Ryan Long <ryan.long@noaa.gov>
+"""
+
+import logging
+import collections
+from typing import Dict
+
+logging.basicConfig(
+    level=logging.DEBUG,
+    format="%(asctime)s %(name)-12s %(levelname)-8s %(message)s",
+    handlers=[logging.StreamHandler()],
+)
+
+
+class JobCard(collections.UserList):
+    """represents a job card to submit to a scheduler"""
+
+    def content(self, line_separator: str = "\n") -> str:
+        """returns the formatted content of the job card"""
+        return line_separator.join(self)
+
+
+class JobScheduler(collections.UserDict):
+
+    _map = {}
+    prefix = ""
+
+    def __getattr__(self, name):
+        if name in self:
+            return self[name]
+
+    @property
+    def job_card(self) -> JobCard:
+        """returns a job card representation"""
+        return JobCard(
+            [
+                f"{self.prefix} {self._map[key] if key in self._map else key + '='}{value}"
+                for (key, value) in self.items()
+            ]
+        )
+
+    @classmethod
+    def get_scheduler(cls, props: Dict[str, str]) -> "JobScheduler":
+        """returns the appropriate scheduler
+
+        TODO: map_schedulers should be hoisted up out of the method
+        """
+        if "scheduler" not in props:
+            raise KeyError(
+                f"no scheduler defined in props: [{', '.join(props.keys())}]"
+            )
+
+        map_schedulers = {"slurm": Slurm, "pbs": PBS, "lsf": LSF, object: None}
+        logging.debug("getting scheduler type %s", map_schedulers[props["scheduler"]])
+        return map_schedulers[props["scheduler"]](props)
+
+
+class Slurm(JobScheduler):
+    """represents a Slurm based scheduler"""
+
+    prefix = "#SBATCH"
+
+    _map = {
+        "job_name": "--job-name=",
+        "output": "--output=",
+        "error": "--error=",
+        "wall_time": "--time=",
+        "partition": "--partition=",
+        "account": "--account=",
+        "nodes": "--nodes=",
+        "number_tasks": "--ntasks-per-node=",
+    }
+
+
+class PBS(JobScheduler):
+    """represents a PBS based scheduler"""
+
+    prefix = "#PBS"
+
+    _map = {
+        "bash": "-S",
+        "job_name": "-N",
+        "output": "-o",
+        "job_name": "-j",  # TODO 2 job name defs
+        "queue": "-q",
+        "account": "-A",
+        "wall_time": "-l walltime=",
+        "total_nodes": "-l select=",
+        "cpus": "cpus=",
+        "place": "-l place=",
+        "debug": "-l debug=",
+    }
+
+
+class LSF(JobScheduler):
+    """represents a LSF based scheduler"""
+
+    _map = {
+        "bash": "-L",
+        "job_name": "-J",
+        "output": "-o",
+        "queue": "-q",
+        "account": "-P",
+        "wall_time": "-W",
+        "total_nodes": "-n",
+        "cpus": "-R affinity[core()]",  # TODO
+        "number_tasks": "-R span[ptile=]",  # TODO
+        "change_dir": "-cwd /tmp",
+    }
+
+    prefix = "#BSUB"
+
+
+if __name__ == "__main__":
+    pass

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,1 @@
+python -m pytest --cov=src --cov-report html

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,0 +1,47 @@
+# pylint: disable=all
+import pytest
+
+from src.uwtools.scheduler import JobScheduler
+
+
+def test_dummy():
+    """Skip the test. Used only as a placeholder."""
+    return True
+
+
+def test_scheduler():
+
+    expected = """#SBATCH scheduler=slurm
+#SBATCH --job-name=abcd
+#SBATCH extra_stuff=12345"""
+
+    props = {"scheduler": "slurm", "job_name": "abcd", "extra_stuff": "12345"}
+
+    js = JobScheduler.get_scheduler(props)
+    actual = js.job_card.content()
+
+    assert actual == expected
+
+
+def test_scheduler_dot_notation():
+
+    props = {"scheduler": "slurm", "job_name": "abcd", "extra_stuff": "12345"}
+
+    js = JobScheduler.get_scheduler(props)
+    expected = "abcd"
+    actual = js.job_name
+
+    assert actual == expected
+
+
+def test_scheduler_prop_not_defined_raises_key_error():
+    with pytest.raises(KeyError) as error:
+        props = {
+            "job_name": "abcd",
+            "extra_stuff": "12345",
+        }
+
+        JobScheduler.get_scheduler(props)
+    expected = "no scheduler defined in props: [job_name, extra_stuff]"
+    actual = str(error.value)
+    assert expected in actual

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,7 @@
+[tox]
+envlist = py35, py36, py37, py38, py39, py310
+
+[testenv]
+commands = pytest
+deps =
+    pytest


### PR DESCRIPTION
Description

The original command pylint *py does not search recursively.

Updated per https://stackoverflow.com/questions/36873096/run-pylint-for-all-python-files-in-a-directory-and-all-subdirectories.

Fixes https://github.com/ufs-community/workflow-tools/issues/22

Type of change
Update pylint command to act recursively.

How Has This Been Tested?
Running the pylint command via the CLI.