### PR TITLE
Break codeowners for reviewing.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,5 +5,8 @@
 # the repo. Unless a later match takes precedence,
 # @global-owner1 and @global-owner2 will be requested for
 # review when someone opens a pull request.
-*       @aerorahul @benjamin-cash @christinaholtNOAA @fgabelmannjr @ope-adejumo
+*       @aerorahul @benjamin-cash @christinaholtNOAA @fgabelmannjr
 
+*.py    @aerorahul @ryanlong1004 @ope-adejumo
+
+docs/*   @aerorahul @jprestop

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,6 +7,6 @@
 # review when someone opens a pull request.
 *       @aerorahul @benjamin-cash @christinaholtNOAA @fgabelmannjr
 
-*.py    @aerorahul @ryanlong1004 @ope-adejumo
+*.py    @aerorahul @ryanlong1004 @ope-adejumo @christinaholtNOAA
 
 docs/*   @aerorahul @jprestop


### PR DESCRIPTION
This draft PR just adds reviewers following Github documentation.
