### PR TITLE
update CODEOWNERS to remove automatic PR review requests from @aerorahul

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,8 +5,8 @@
 # the repo. Unless a later match takes precedence,
 # @global-owner1 and @global-owner2 will be requested for
 # review when someone opens a pull request.
-*       @aerorahul @benjamin-cash @christinaholtNOAA @fgabelmannjr
+*       @benjamin-cash @christinaholtNOAA @fgabelmannjr
 
-*.py    @aerorahul @ryanlong1004 @ope-adejumo @christinaholtNOAA
+*.py    @ryanlong1004 @ope-adejumo @christinaholtNOAA
 
-docs/*   @aerorahul @jprestop
+docs/*  @jprestop


### PR DESCRIPTION
This PR removes `@aerorahul` from the list of CODEOWNERS.
PR reviews should be requested automatically by default from owners of the code.
Other users can be requested to review if necessary.