### PR TITLE
UW 203 User interface for handling config files

### DIFF
--- a/src/uwtools/set_config.py
+++ b/src/uwtools/set_config.py
@@ -40,7 +40,7 @@ def parse_args(argv):
         required=True,
         type=path_if_file_exists,
         )
-        
+
     parser.add_argument(
         '-o', '--outfile',
         help='Full path to output file',
@@ -62,9 +62,8 @@ def parse_args(argv):
 
 def create_config_obj (argv):
     '''Main section for processing config file'''
-    user_args = parse_args(argv)
 
-    # check input type
+    user_args = parse_args(argv)
     file_type = get_file_type(user_args.input_base_file)
 
     if file_type in [".yaml", ".yml"]:
@@ -75,10 +74,8 @@ def create_config_obj (argv):
 
     elif file_type == ".nml":
         config_obj = config.F90Config (user_args.input_base_file)
-    
-    # else return error?
 
-    # If user provided -c config, load it and update config_obj
+
     if user_args.config_file:
         config_file_type = get_file_type(user_args.config_file)
 

--- a/src/uwtools/set_config.py
+++ b/src/uwtools/set_config.py
@@ -67,26 +67,29 @@ def create_config_obj (argv):
     # check input type
     file_type = get_file_type(user_args.input_base_file)
 
-    if file_type in ["yaml", "yml"]:
+    if file_type in [".yaml", ".yml"]:
         config_obj = config.YAMLConfig(user_args.input_base_file)
 
-    elif file_type in ["bash", "sh", "ini", "IN"]:
+    elif file_type in [".bash", ".sh", ".ini", ".IN"]:
         config_obj = config.INIConfig (user_args.input_base_file)
 
-    elif file_type == "nml":
+    elif file_type == ".nml":
         config_obj = config.F90Config (user_args.input_base_file)
+    
+    else:
+        config_obj = user_args.input_base_file
 
     # If user provided -c config, load it and update config_obj
     if user_args.config_file:
         config_file_type = get_file_type(user_args.config_file)
 
-        if config_file_type in ["yaml", "yml"]:
+        if config_file_type in [".yaml", ".yml"]:
             user_config_obj = config.YAMLConfig(user_args.config_file)
 
-        elif config_file_type in ["bash", "sh", "ini", "IN"]:
+        elif config_file_type in [".bash", ".sh", ".ini", ".IN"]:
             user_config_obj = config.INIConfig (user_args.config_file)
 
-        elif config_file_type == "nml":
+        elif config_file_type == ".nml":
             user_config_obj = config.F90Config (user_args.config_file)
 
         config_obj.update_values(user_config_obj)

--- a/src/uwtools/set_config.py
+++ b/src/uwtools/set_config.py
@@ -18,7 +18,7 @@ def path_if_file_exists(arg):
         raise argparse.ArgumentTypeError(msg)
     return arg
 
-def get_file_type (arg):
+def get_file_type(arg):
     '''Gets the file type from the path'''
     return pathlib.Path(path_if_file_exists(arg)).suffix
 
@@ -60,7 +60,7 @@ def parse_args(argv):
     return parser.parse_args(argv)
 
 
-def create_config_obj (argv):
+def create_config_obj(argv):
     '''Main section for processing config file'''
 
     user_args = parse_args(argv)

--- a/src/uwtools/set_config.py
+++ b/src/uwtools/set_config.py
@@ -76,7 +76,7 @@ def create_config_obj (argv):
         config_obj = config.F90Config(user_args.input_base_file)
 
     else:
-        print ("Set config failure: bad file type")
+        print("Set config failure: bad file type")
 
 
     if user_args.config_file:

--- a/src/uwtools/set_config.py
+++ b/src/uwtools/set_config.py
@@ -1,8 +1,14 @@
+#!/usr/bin/env python3
+
+'''
+This utility creates a command line interface for handling config files.
+'''
 import os
+import sys
 import argparse
 import pathlib
 from uwtools import config
-from uwtools import Logger
+# from uwtools import logger
 
 
 def path_if_file_exists(arg):
@@ -98,3 +104,6 @@ def create_config_obj (argv):
     #     else:
     #         config_obj.dump_file(user_args.outfile)
 
+if __name__ == '__main__':
+    create_config_obj(sys.argv[1:])
+    

--- a/src/uwtools/set_config.py
+++ b/src/uwtools/set_config.py
@@ -8,7 +8,7 @@ import sys
 import argparse
 import pathlib
 from uwtools import config
-# from uwtools import logger
+
 
 
 def path_if_file_exists(arg):
@@ -95,16 +95,6 @@ def create_config_obj (argv):
 
     if user_args.outfile:
         config_obj.dump_file(user_args.outfile)
-
-    # if user_args.dry_run:
-    #     if user_args.outfile:
-    #         log.info(r"warning file {outfile} ".format(outfile=user_args.outfile),
-    #              r"not written when using --dry_run")
-    #         # apply switch to allow user to view the results of rendered template
-    #         # instead of writing to disk
-    #         log.info(config_obj)
-    #     else:
-    #         config_obj.dump_file(user_args.outfile)
 
 if __name__ == '__main__':
     create_config_obj(sys.argv[1:])

--- a/src/uwtools/set_config.py
+++ b/src/uwtools/set_config.py
@@ -76,8 +76,7 @@ def create_config_obj (argv):
     elif file_type == ".nml":
         config_obj = config.F90Config (user_args.input_base_file)
     
-    else:
-        config_obj = user_args.input_base_file
+    # else return error?
 
     # If user provided -c config, load it and update config_obj
     if user_args.config_file:

--- a/src/uwtools/set_config.py
+++ b/src/uwtools/set_config.py
@@ -1,0 +1,100 @@
+import os
+import argparse
+import pathlib
+from uwtools import config
+from uwtools import Logger
+
+
+def path_if_file_exists(arg):
+    '''Checks whether a file exists, and returns the path if it does.'''
+    if not os.path.exists(arg):
+        msg = f'{arg} does not exist!'
+        raise argparse.ArgumentTypeError(msg)
+    return arg
+
+def get_file_type (arg):
+    '''Gets the file type from the path'''
+    return pathlib.Path(path_if_file_exists(arg)).suffix
+
+def parse_args(argv):
+
+    '''
+    Function maintains the arguments accepted by this script. Please see
+    Python's argparse documentation for more information about settings of each
+    argument.
+    '''
+
+    parser = argparse.ArgumentParser(
+       description='Set config with user-defined settings.'
+    )
+
+    parser.add_argument(
+        '-i', '--input_base_file',
+        help='Path to a config base file.',
+        required=True,
+        type=path_if_file_exists,
+        )
+        
+    parser.add_argument(
+        '-o', '--outfile',
+        help='Full path to output file',
+        )
+
+    parser.add_argument(
+        '-c', '--config_file',
+        help='Optional path to configuration file',
+        type=path_if_file_exists,
+    )
+
+    parser.add_argument(
+        '-d', '--dry_run',
+        action='store_true',
+        help='If provided, print rendered config file to stdout only',
+    )
+    return parser.parse_args(argv)
+
+
+def create_config_obj (argv):
+    '''Main section for processing config file'''
+    user_args = parse_args(argv)
+
+    # check input type
+    file_type = get_file_type(user_args.input_base_file)
+
+    if file_type in ["yaml", "yml"]:
+        config_obj = config.YAMLConfig(user_args.input_base_file)
+
+    elif file_type in ["bash", "sh", "ini", "IN"]:
+        config_obj = config.INIConfig (user_args.input_base_file)
+
+    elif file_type == "nml":
+        config_obj = config.F90Config (user_args.input_base_file)
+
+    # If user provided -c config, load it and update config_obj
+    if user_args.config_file:
+        config_file_type = get_file_type(user_args.config_file)
+
+        if config_file_type in ["yaml", "yml"]:
+            user_config_obj = config.YAMLConfig(user_args.config_file)
+
+        elif config_file_type in ["bash", "sh", "ini", "IN"]:
+            user_config_obj = config.INIConfig (user_args.config_file)
+
+        elif config_file_type == "nml":
+            user_config_obj = config.F90Config (user_args.config_file)
+
+        config_obj.update_values(user_config_obj)
+
+    if user_args.outfile:
+        config_obj.dump_file(user_args.outfile)
+
+    # if user_args.dry_run:
+    #     if user_args.outfile:
+    #         log.info(r"warning file {outfile} ".format(outfile=user_args.outfile),
+    #              r"not written when using --dry_run")
+    #         # apply switch to allow user to view the results of rendered template
+    #         # instead of writing to disk
+    #         log.info(config_obj)
+    #     else:
+    #         config_obj.dump_file(user_args.outfile)
+

--- a/src/uwtools/set_config.py
+++ b/src/uwtools/set_config.py
@@ -70,10 +70,13 @@ def create_config_obj (argv):
         config_obj = config.YAMLConfig(user_args.input_base_file)
 
     elif file_type in [".bash", ".sh", ".ini", ".IN"]:
-        config_obj = config.INIConfig (user_args.input_base_file)
+        config_obj = config.INIConfig(user_args.input_base_file)
 
     elif file_type == ".nml":
-        config_obj = config.F90Config (user_args.input_base_file)
+        config_obj = config.F90Config(user_args.input_base_file)
+
+    else:
+        print ("Set config failure: bad file type")
 
 
     if user_args.config_file:
@@ -83,10 +86,10 @@ def create_config_obj (argv):
             user_config_obj = config.YAMLConfig(user_args.config_file)
 
         elif config_file_type in [".bash", ".sh", ".ini", ".IN"]:
-            user_config_obj = config.INIConfig (user_args.config_file)
+            user_config_obj = config.INIConfig(user_args.config_file)
 
         elif config_file_type == ".nml":
-            user_config_obj = config.F90Config (user_args.config_file)
+            user_config_obj = config.F90Config(user_args.config_file)
 
         config_obj.update_values(user_config_obj)
 

--- a/tests/fixtures/simple2.ini
+++ b/tests/fixtures/simple2.ini
@@ -1,0 +1,8 @@
+[salad]
+base = kale
+fruit = papaya
+vegetable = tomato
+how_many = 17
+dressing = balsamic
+topping = crouton
+

--- a/tests/test_set_config.py
+++ b/tests/test_set_config.py
@@ -1,8 +1,9 @@
+#pylint: disable=unused-variable
 
 '''
 Tests for set_config tool
 '''
-from contextlib import redirect_stdout
+
 import argparse
 import pathlib
 import os
@@ -44,37 +45,32 @@ def test_path_if_file_exists():
     with pytest.raises(argparse.ArgumentTypeError):
         not_a_filepath = './no_way_this_file_exists.nope'
         set_config.path_if_file_exists(not_a_filepath)
-        
 
 def test_set_config_yaml_simple ():
     ''' Test that providing a YAML base file with necessary settings 
     will create a YAML config file'''
 
-    # get input file
     input_file = os.path.join(uwtools_file_base, pathlib.Path("fixtures/simple2.yaml"))
-    # create a temporary directory for outfile and expected file
+
     with tempfile.TemporaryDirectory(dir='.') as tmp_dir:
-        # set outfile in temp directory
+
         out_file = f'{tmp_dir}/test_config_from_yaml.yaml'
-        # create args for create_config_obj input
         args = ['-i', input_file, '-o', out_file]
-        # create config obj from commandline inputs
+
         set_config.create_config_obj(args)
-        # create expected file using config.py
+
         expected = config.YAMLConfig(input_file)
         expected_file = f'{tmp_dir}/expected_yaml.yaml'
         expected.dump_file(expected_file)
-        
-        # compare outfile and expected file
+
         assert compare_files(expected_file, out_file)
-    
+
 def test_set_config_ini_simple ():
     ''' Test that providing a basic INI file with necessary settings 
     will create an INI config file'''
 
-    #get input file 
     input_file = os.path.join(uwtools_file_base, pathlib.Path("fixtures/simple.ini"))
-    # create a temp directory for outfile and expected file
+
     with tempfile.TemporaryDirectory(dir='.') as tmp_dr:
         out_file = f'{tmp_dr}/test_config_from_ini.ini'
         args = ['-i', input_file, '-o', out_file]
@@ -137,7 +133,7 @@ def test_set_config_yaml_config_file ():
 
         out_file = f'{tmp_dir}/test_config_from_yaml.yaml'
         args = ['-i', input_file, '-o', out_file, '-c', config_file]
-   
+
         set_config.create_config_obj(args)
 
         expected = config.YAMLConfig(input_file)
@@ -159,7 +155,7 @@ def test_set_config_f90nml_config_file ():
 
         out_file = f'{tmp_dir}/test_config_from_nml.nml'
         args = ['-i', input_file, '-o', out_file, '-c', config_file]
-   
+
         set_config.create_config_obj(args)
 
         expected = config.F90Config(input_file)
@@ -175,14 +171,13 @@ def test_set_config_ini_config_file ():
     create and update INI config file'''
 
     input_file = os.path.join(uwtools_file_base, pathlib.Path("fixtures/simple.ini"))
-    # config using bash file
     config_file = os.path.join(uwtools_file_base, pathlib.Path("fixtures/simple2.ini"))
 
     with tempfile.TemporaryDirectory(dir='.') as tmp_dir:
 
         out_file = f'{tmp_dir}/test_config_from_ini.ini'
         args = ['-i', input_file, '-o', out_file, '-c', config_file]
-   
+
         set_config.create_config_obj(args)
 
         expected = config.INIConfig(input_file)
@@ -198,14 +193,13 @@ def test_set_config_ini_bash_config_file ():
     create and update INI config file'''
 
     input_file = os.path.join(uwtools_file_base, pathlib.Path("fixtures/simple.ini"))
-    # config using bash file
     config_file = os.path.join(uwtools_file_base, pathlib.Path("fixtures/fruit_config.sh"))
 
     with tempfile.TemporaryDirectory(dir='.') as tmp_dir:
 
         out_file = f'{tmp_dir}/test_config_from_ini.ini'
         args = ['-i', input_file, '-o', out_file, '-c', config_file]
-   
+
         set_config.create_config_obj(args)
 
         expected = config.INIConfig(input_file)
@@ -215,8 +209,3 @@ def test_set_config_ini_bash_config_file ():
         expected.dump_file(expected_file)
 
         assert compare_files(expected_file, out_file)
-
-
-
-# questions
-# how does it handle when no outfile provided?  how do we test for that?

--- a/tests/test_set_config.py
+++ b/tests/test_set_config.py
@@ -1,11 +1,9 @@
-#pylint: disable=unused-variable
 
 '''
 Tests for set_config tool
 '''
 from contextlib import redirect_stdout
 import argparse
-import io
 import pathlib
 import os
 import tempfile

--- a/tests/test_set_config.py
+++ b/tests/test_set_config.py
@@ -24,15 +24,15 @@ def compare_files(expected, actual):
 
     with open(expected, 'r', encoding='utf-8') as expected_file:
         expected_content = expected_file.read().rstrip('\n')
-    with open (actual, 'r', encoding='utf-8') as actual_file:
+    with open(actual, 'r', encoding='utf-8') as actual_file:
         actual_content = actual_file.read().rstrip('\n')
 
     if expected_content != actual_content:
-        print ('The expected file looks like:')
-        print (expected_content)
-        print ('*' * 80)
-        print ('The rendered file looks like:')
-        print (actual_content)
+        print('The expected file looks like:')
+        print(expected_content)
+        print('*' * 80)
+        print('The rendered file looks like:')
+        print(actual_content)
         return False
     return True
 
@@ -104,7 +104,7 @@ def test_set_config_f90nml_simple():
 
         assert compare_files(expected_file, out_file)
 
-def test_set_config_bash_simple ():
+def test_set_config_bash_simple():
     '''Test that providing bash file with necessary settings will 
     create an INI config file'''
 
@@ -124,7 +124,7 @@ def test_set_config_bash_simple ():
 
         assert compare_files(expected_file, out_file)
 
-def test_set_config_yaml_config_file ():
+def test_set_config_yaml_config_file():
     '''Test that providing a yaml base input file and a config file will
     create and update yaml config file'''
 
@@ -146,7 +146,7 @@ def test_set_config_yaml_config_file ():
 
         assert compare_files(expected_file, out_file)
 
-def test_set_config_f90nml_config_file ():
+def test_set_config_f90nml_config_file():
     '''Test that providing a F90nml base input file and a config file will
     create and update F90nml config file'''
 

--- a/tests/test_set_config.py
+++ b/tests/test_set_config.py
@@ -1,0 +1,67 @@
+#pylint: disable=unused-variable
+
+'''
+Tests for set_config tool
+'''
+from contextlib import redirect_stdout
+import argparse
+import io
+import pathlib
+import os
+import tempfile
+import pytest
+from uwtools import config
+from uwtools import set_config
+
+
+uwtools_file_base = os.path.join(os.path.dirname(__file__))
+
+def compare_files(expected, actual):
+    '''Compare the content of two files.  Doing this over filecmp.cmp since 
+    we may not be able to handle end-of-file character differences with it.
+    Prints the contents of two compared files to std out if they do not match.'''
+
+    with open(expected, 'r', encoding='utf-8') as expected_file:
+        expected_content = expected_file.read().rstrip('\n')
+    with open (actual, 'r', encoding='utf-8') as actual_file:
+        actual_content = actual_file.read().rstrip('\n')
+
+    if expected_content != actual_content:
+        print ('The expected file looks like:')
+        print (expected_content)
+        print ('*' * 80)
+        print ('The rendered file looks like:')
+        print (actual_content)
+        return False
+    return True
+
+def test_path_if_file_exists():
+    '''Make sure the function works as expected.  It is used as a type in 
+    argparse, so raises an argparse exception when the user provides a 
+    non-existant path.'''
+
+    with tempfile.NamedTemporaryFile(dir='.', mode='w') as tmp_file:
+        assert set_config.path_if_file_exists(tmp_file.name)
+
+    with pytest.raises(argparse.ArgumentTypeError):
+        not_a_filepath = './no_way_this_file_exists.nope'
+        set_config.path_if_file_exists(not_a_filepath)
+        
+
+# test command line with input file
+# seperate test for every file type
+
+def test_set_config_yaml_simple ():
+    ''' Test that providing a YAML base file with necessary settings 
+    will create a YAML config file'''
+
+    input_file = os.path.join(uwtools_file_base, pathlib.Path("fixtures/simple2.yaml"))
+    with tempfile.TemporaryDirectory(dir='.') as tmp_dir:
+        out_file = f'{tmp_dir}/test_config_from_yaml.yaml'
+    
+
+    args = ['-i', input_file, '-o', out_file]
+    set_config.create_config_obj(args)
+    expected_file = config.YAMLConfig(input_file)
+    assert compare_files(expected_file, out_file)
+    

--- a/tests/test_set_config.py
+++ b/tests/test_set_config.py
@@ -55,13 +55,21 @@ def test_set_config_yaml_simple ():
     ''' Test that providing a YAML base file with necessary settings 
     will create a YAML config file'''
 
+    # get input file
     input_file = os.path.join(uwtools_file_base, pathlib.Path("fixtures/simple2.yaml"))
+    # create a temporary directory for outfile and expected file
     with tempfile.TemporaryDirectory(dir='.') as tmp_dir:
+        # set outfile in temp directory
         out_file = f'{tmp_dir}/test_config_from_yaml.yaml'
-    
-
-    args = ['-i', input_file, '-o', out_file]
-    set_config.create_config_obj(args)
-    expected_file = config.YAMLConfig(input_file)
-    assert compare_files(expected_file, out_file)
+        # create args for create_config_obj input
+        args = ['-i', input_file, '-o', out_file]
+        # create config obj from commandline inputs
+        set_config.create_config_obj(args)
+        # create expected file using config.py
+        expected = config.YAMLConfig(input_file)
+        expected_file = f'{tmp_dir}/expected_yaml.yaml'
+        expected.dump_file(expected_file)
+        
+        # compare outfile and expected file
+        assert compare_files(expected_file, out_file)
     

--- a/tests/test_set_config.py
+++ b/tests/test_set_config.py
@@ -132,8 +132,8 @@ def test_set_config_yaml_config_file ():
     '''Test that providing a yaml base input file and a config file will
     create and update yaml config file'''
 
-    input_file = os.path.join(uwtools_file_base, pathlib.Path("fixtures/simple2.yaml"))
-    config_file = os.path.join(uwtools_file_base, pathlib.Path("fixtures/fruit_config.yaml"))
+    input_file = os.path.join(uwtools_file_base, pathlib.Path("fixtures/fruit_config.yaml"))
+    config_file = os.path.join(uwtools_file_base, pathlib.Path("fixtures/fruit_config_similar.yaml"))
 
     with tempfile.TemporaryDirectory(dir='.') as tmp_dir:
 
@@ -154,8 +154,8 @@ def test_set_config_f90nml_config_file ():
     '''Test that providing a F90nml base input file and a config file will
     create and update F90nml config file'''
 
-    input_file = os.path.join(uwtools_file_base, pathlib.Path("fixtures/simple2.nml"))
-    config_file = os.path.join(uwtools_file_base, pathlib.Path("fixtures/fruit_config.nml"))
+    input_file = os.path.join(uwtools_file_base, pathlib.Path("fixtures/simple.nml"))
+    config_file = os.path.join(uwtools_file_base, pathlib.Path("fixtures/simple2.nml"))
 
     with tempfile.TemporaryDirectory(dir='.') as tmp_dir:
 
@@ -173,6 +173,29 @@ def test_set_config_f90nml_config_file ():
         assert compare_files(expected_file, out_file)
 
 def test_set_config_ini_config_file ():
+    '''Test that aproviding INI base input file and a config file will 
+    create and update INI config file'''
+
+    input_file = os.path.join(uwtools_file_base, pathlib.Path("fixtures/simple.ini"))
+    # config using bash file
+    config_file = os.path.join(uwtools_file_base, pathlib.Path("fixtures/simple2.ini"))
+
+    with tempfile.TemporaryDirectory(dir='.') as tmp_dir:
+
+        out_file = f'{tmp_dir}/test_config_from_ini.ini'
+        args = ['-i', input_file, '-o', out_file, '-c', config_file]
+   
+        set_config.create_config_obj(args)
+
+        expected = config.INIConfig(input_file)
+        config_file_obj = config.INIConfig(config_file)
+        expected.update_values(config_file_obj)
+        expected_file = f'{tmp_dir}/expected_ini.ini'
+        expected.dump_file(expected_file)
+
+        assert compare_files(expected_file, out_file)
+
+def test_set_config_ini_bash_config_file ():
     '''Test that aproviding INI base input file and a config file will 
     create and update INI config file'''
 

--- a/tests/test_set_config.py
+++ b/tests/test_set_config.py
@@ -48,9 +48,6 @@ def test_path_if_file_exists():
         set_config.path_if_file_exists(not_a_filepath)
         
 
-# test command line with input file
-# seperate test for every file type
-
 def test_set_config_yaml_simple ():
     ''' Test that providing a YAML base file with necessary settings 
     will create a YAML config file'''
@@ -73,3 +70,132 @@ def test_set_config_yaml_simple ():
         # compare outfile and expected file
         assert compare_files(expected_file, out_file)
     
+def test_set_config_ini_simple ():
+    ''' Test that providing a basic INI file with necessary settings 
+    will create an INI config file'''
+
+    #get input file 
+    input_file = os.path.join(uwtools_file_base, pathlib.Path("fixtures/simple.ini"))
+    # create a temp directory for outfile and expected file
+    with tempfile.TemporaryDirectory(dir='.') as tmp_dr:
+        out_file = f'{tmp_dr}/test_config_from_ini.ini'
+        args = ['-i', input_file, '-o', out_file]
+
+        set_config.create_config_obj(args)
+
+        expected = config.INIConfig(input_file)
+        expected_file = f'{tmp_dr}/expected_ini.ini'
+        expected.dump_file(expected_file)
+
+        assert compare_files(expected_file, out_file)
+
+def test_set_config_f90nml_simple ():
+    '''Test that providing basic f90nml file with necessary settings
+    will create f90nml config file'''
+
+    input_file = os.path.join(uwtools_file_base, pathlib.Path("fixtures/simple.nml"))
+
+    with tempfile.TemporaryDirectory(dir='.') as tmp_dr:
+
+        out_file = f'{tmp_dr}/test_config_from_nml.nml'
+        args = ['-i', input_file, '-o', out_file]
+
+        set_config.create_config_obj(args)
+
+        expected = config.F90Config(input_file)
+        expected_file = f'{tmp_dr}/expected_nml.nml'
+        expected.dump_file(expected_file)
+
+        assert compare_files(expected_file, out_file)
+
+def test_set_config_bash_simple ():
+    '''Test that providing bash file with necessary settings will 
+    create an INI config file'''
+
+    input_file = os.path.join(uwtools_file_base, pathlib.Path("fixtures/simple.sh"))
+
+    with tempfile.TemporaryDirectory(dir='.') as tmp_dr:
+
+        out_file = f'{tmp_dr}/test_config_from_bash.ini'
+
+        args = ['-i', input_file, '-o', out_file]
+
+        set_config.create_config_obj(args)
+
+        expected = config.INIConfig(input_file)
+        expected_file = f'{tmp_dr}/expected_ini.ini'
+        expected.dump_file(expected_file)
+
+        assert compare_files(expected_file, out_file)
+
+def test_set_config_yaml_config_file ():
+    '''Test that providing a yaml base input file and a config file will
+    create and update yaml config file'''
+
+    input_file = os.path.join(uwtools_file_base, pathlib.Path("fixtures/simple2.yaml"))
+    config_file = os.path.join(uwtools_file_base, pathlib.Path("fixtures/fruit_config.yaml"))
+
+    with tempfile.TemporaryDirectory(dir='.') as tmp_dir:
+
+        out_file = f'{tmp_dir}/test_config_from_yaml.yaml'
+        args = ['-i', input_file, '-o', out_file, '-c', config_file]
+   
+        set_config.create_config_obj(args)
+
+        expected = config.YAMLConfig(input_file)
+        config_file_obj = config.YAMLConfig(config_file)
+        expected.update_values(config_file_obj)
+        expected_file = f'{tmp_dir}/expected_yaml.yaml'
+        expected.dump_file(expected_file)
+
+        assert compare_files(expected_file, out_file)
+
+def test_set_config_f90nml_config_file ():
+    '''Test that providing a F90nml base input file and a config file will
+    create and update F90nml config file'''
+
+    input_file = os.path.join(uwtools_file_base, pathlib.Path("fixtures/simple2.nml"))
+    config_file = os.path.join(uwtools_file_base, pathlib.Path("fixtures/fruit_config.nml"))
+
+    with tempfile.TemporaryDirectory(dir='.') as tmp_dir:
+
+        out_file = f'{tmp_dir}/test_config_from_nml.nml'
+        args = ['-i', input_file, '-o', out_file, '-c', config_file]
+   
+        set_config.create_config_obj(args)
+
+        expected = config.F90Config(input_file)
+        config_file_obj = config.F90Config(config_file)
+        expected.update_values(config_file_obj)
+        expected_file = f'{tmp_dir}/expected_nml.nml'
+        expected.dump_file(expected_file)
+
+        assert compare_files(expected_file, out_file)
+
+def test_set_config_ini_config_file ():
+    '''Test that aproviding INI base input file and a config file will 
+    create and update INI config file'''
+
+    input_file = os.path.join(uwtools_file_base, pathlib.Path("fixtures/simple.ini"))
+    # config using bash file
+    config_file = os.path.join(uwtools_file_base, pathlib.Path("fixtures/fruit_config.sh"))
+
+    with tempfile.TemporaryDirectory(dir='.') as tmp_dir:
+
+        out_file = f'{tmp_dir}/test_config_from_ini.ini'
+        args = ['-i', input_file, '-o', out_file, '-c', config_file]
+   
+        set_config.create_config_obj(args)
+
+        expected = config.INIConfig(input_file)
+        config_file_obj = config.INIConfig(config_file)
+        expected.update_values(config_file_obj)
+        expected_file = f'{tmp_dir}/expected_ini.ini'
+        expected.dump_file(expected_file)
+
+        assert compare_files(expected_file, out_file)
+
+
+
+# questions
+# how does it handle when no outfile provided?  how do we test for that?

--- a/tests/test_set_config.py
+++ b/tests/test_set_config.py
@@ -8,6 +8,8 @@ import argparse
 import pathlib
 import os
 import tempfile
+import io
+from contextlib import redirect_stdout
 import pytest
 from uwtools import config
 from uwtools import set_config
@@ -46,7 +48,7 @@ def test_path_if_file_exists():
         not_a_filepath = './no_way_this_file_exists.nope'
         set_config.path_if_file_exists(not_a_filepath)
 
-def test_set_config_yaml_simple ():
+def test_set_config_yaml_simple():
     ''' Test that providing a YAML base file with necessary settings 
     will create a YAML config file'''
 
@@ -65,7 +67,7 @@ def test_set_config_yaml_simple ():
 
         assert compare_files(expected_file, out_file)
 
-def test_set_config_ini_simple ():
+def test_set_config_ini_simple():
     ''' Test that providing a basic INI file with necessary settings 
     will create an INI config file'''
 
@@ -83,7 +85,7 @@ def test_set_config_ini_simple ():
 
         assert compare_files(expected_file, out_file)
 
-def test_set_config_f90nml_simple ():
+def test_set_config_f90nml_simple():
     '''Test that providing basic f90nml file with necessary settings
     will create f90nml config file'''
 
@@ -166,7 +168,7 @@ def test_set_config_f90nml_config_file ():
 
         assert compare_files(expected_file, out_file)
 
-def test_set_config_ini_config_file ():
+def test_set_config_ini_config_file():
     '''Test that aproviding INI base input file and a config file will 
     create and update INI config file'''
 
@@ -188,7 +190,7 @@ def test_set_config_ini_config_file ():
 
         assert compare_files(expected_file, out_file)
 
-def test_set_config_ini_bash_config_file ():
+def test_set_config_ini_bash_config_file():
     '''Test that aproviding INI base input file and a config file will 
     create and update INI config file'''
 
@@ -209,3 +211,20 @@ def test_set_config_ini_bash_config_file ():
         expected.dump_file(expected_file)
 
         assert compare_files(expected_file, out_file)
+
+def test_incompatible_file_type():
+    '''Test that providing an incompatible file type for input base file will 
+    return print statement'''
+
+    with tempfile.TemporaryDirectory(dir='.') as tmp_dir:
+
+        input_file = os.path.join(uwtools_file_base, pathlib.Path("fixtures/model_configure.sample"))
+        args = ['-i', input_file]
+
+        outstring = io.StringIO()
+        with redirect_stdout(outstring):
+            set_config.create_config_obj(args)
+        result = outstring.getvalue()
+        outcome = "Set config failure: bad file type\n"
+
+        assert result == outcome


### PR DESCRIPTION
**Description**
[Fixes Issue #151 ](https://github.com/ufs-community/workflow-tools/issues/151)

The config parsing tool (probably set_config.py) needs a command line interface for user interaction. It should provide all the standard options as outlined in the [Toolbox MVP](https://confluence-epic.woc.noaa.gov/display/UW/Toolbox+MVP) and should aim at achieving the following behaviors:

-i to accept an input "base" config file (required)
-o to write a rendered output file (optional)
-c to accept a user config file (optional)
These files will need some way of knowing what type of file we give it. As a first pass, I think that determining type from the suffix is sufficient. We'll likely want a better solution at a future date.

Assume the output file type is the same as the input file type in this ticket.

The end purpose of the tool is to update key/value pairs, concatenate sections or key/value pairs, compare two fully formed config files, and transform an input base value to a different output configure type.  We have tickets to handle the full range of these functions. Just do the input/output handling here.

**Type of change**

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [x] pytests in GitHub actions.
- [ ] Tests on XYZ OS/HPC/CSP
-->

**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes need updates to the documentation.  I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [x] Any dependent changes have been merged and published

