### PR TITLE
UW-228: Add dry-run flag to config_parser.

### DIFF
--- a/src/uwtools/set_config.py
+++ b/src/uwtools/set_config.py
@@ -133,13 +133,13 @@ def create_config_obj(argv):
         out_object.dump_file(user_args.outfile)
 
     if user_args.dry_run:
+        log.info(config_obj)
         if user_args.outfile:
             out_object = user_args.outfile
             log.info(f'warning file {out_object} ',
                  r"not written when using --dry_run")
         # apply switch to allow user to view the results of config
         # instead of writing to disk
-    log.info(config_obj)
 
 if __name__ == '__main__':
     create_config_obj(sys.argv[1:])

--- a/src/uwtools/set_config.py
+++ b/src/uwtools/set_config.py
@@ -82,10 +82,6 @@ def create_config_obj(argv):
     user_args = parse_args(argv)
     infile_type = get_file_type(user_args.input_base_file)
 
-    log.info(f"""Running script set_config.py:
-{('-' * 70)}
-{('-' * 70)}""")
-
     if infile_type in [".yaml", ".yml"]:
         config_obj = config.YAMLConfig(user_args.input_base_file)
         infile_type = ".yaml"
@@ -143,8 +139,6 @@ def create_config_obj(argv):
                  r"not written when using --dry_run")
         # apply switch to allow user to view the results of config
         # instead of writing to disk
-    elif user_args.outfile:
-        config_obj.dump_file(user_args.outfile)
     log.info(config_obj)
 
 if __name__ == '__main__':

--- a/src/uwtools/set_config.py
+++ b/src/uwtools/set_config.py
@@ -94,8 +94,8 @@ def create_config_obj(argv):
         config_obj = config.F90Config(user_args.input_base_file)
 
     else:
-        config_obj = None
         log.info("Set config failure: bad file type")
+        return
 
 
     if user_args.config_file:
@@ -121,8 +121,8 @@ def create_config_obj(argv):
                  r"not written when using --dry_run")
         # apply switch to allow user to view the results of config
         # instead of writing to disk
-    if config_obj is not None:
         log.info(config_obj)
+        return
 
     if user_args.outfile:
         outfile_type = get_file_type(user_args.outfile)

--- a/src/uwtools/set_config.py
+++ b/src/uwtools/set_config.py
@@ -94,9 +94,8 @@ def create_config_obj(argv):
         config_obj = config.F90Config(user_args.input_base_file)
 
     else:
-        print("Set config failure: bad file type")
-        log.info(f'warning file {user_args.input_base_file} ',
-                 r"has incorrect file type")
+        config_obj = None
+        log.info("Set config failure: bad file type")
 
 
     if user_args.config_file:
@@ -115,6 +114,16 @@ def create_config_obj(argv):
 
         config_obj.update_values(user_config_obj)
 
+    if user_args.dry_run:
+        if user_args.outfile:
+            out_object = user_args.outfile
+            log.info(f'warning file {out_object} ',
+                 r"not written when using --dry_run")
+        # apply switch to allow user to view the results of config
+        # instead of writing to disk
+    if config_obj is not None:
+        log.info(config_obj)
+
     if user_args.outfile:
         outfile_type = get_file_type(user_args.outfile)
         if outfile_type != infile_type:
@@ -131,15 +140,6 @@ def create_config_obj(argv):
         else: # same type of file as input, no need to convert it
             out_object = config_obj
         out_object.dump_file(user_args.outfile)
-
-    if user_args.dry_run:
-        log.info(config_obj)
-        if user_args.outfile:
-            out_object = user_args.outfile
-            log.info(f'warning file {out_object} ',
-                 r"not written when using --dry_run")
-        # apply switch to allow user to view the results of config
-        # instead of writing to disk
 
 if __name__ == '__main__':
     create_config_obj(sys.argv[1:])

--- a/src/uwtools/set_config.py
+++ b/src/uwtools/set_config.py
@@ -9,6 +9,7 @@ import sys
 import argparse
 import pathlib
 from uwtools import config
+from uwtools.logger import Logger
 
 
 
@@ -71,8 +72,19 @@ def parse_args(argv):
 def create_config_obj(argv):
     '''Main section for processing config file'''
 
+    logfile = os.path.join(os.path.dirname(__file__), "set_config.log")
+    log = Logger(level='info',
+        _format='%(message)s',
+        colored_log= False,
+        logfile_path=logfile
+        )
+
     user_args = parse_args(argv)
     infile_type = get_file_type(user_args.input_base_file)
+
+    log.info(f"""Running script set_config.py:
+{('-' * 70)}
+{('-' * 70)}""")
 
     if infile_type in [".yaml", ".yml"]:
         config_obj = config.YAMLConfig(user_args.input_base_file)
@@ -87,6 +99,8 @@ def create_config_obj(argv):
 
     else:
         print("Set config failure: bad file type")
+        log.info(f'warning file {user_args.input_base_file} ',
+                 r"has incorrect file type")
 
 
     if user_args.config_file:
@@ -121,6 +135,17 @@ def create_config_obj(argv):
         else: # same type of file as input, no need to convert it
             out_object = config_obj
         out_object.dump_file(user_args.outfile)
+
+    if user_args.dry_run:
+        if user_args.outfile:
+            out_object = user_args.outfile
+            log.info(f'warning file {out_object} ',
+                 r"not written when using --dry_run")
+        # apply switch to allow user to view the results of config
+        # instead of writing to disk
+    elif user_args.outfile:
+        config_obj.dump_file(user_args.outfile)
+    log.info(config_obj)
 
 if __name__ == '__main__':
     create_config_obj(sys.argv[1:])

--- a/tests/test_set_config.py
+++ b/tests/test_set_config.py
@@ -247,3 +247,23 @@ def test_set_config_field_table():
             lines = zip(outlist, reflist)
             for line1, line2 in lines:
                 assert line1 in line2
+
+def test_set_config_dry_run():
+    ''' Test that providing a YAML base file with a dry run flag 
+    will print an YAML config file'''
+
+    with tempfile.TemporaryDirectory(dir='.') as tmp_dir:
+
+        input_file = os.path.join(uwtools_file_base, pathlib.Path("fixtures/fruit_config.yaml"))
+
+        args = ['-i', input_file, '-d']
+
+        expected = config.YAMLConfig(input_file)
+        expected_content = str(expected)
+
+        outstring = io.StringIO()
+        with redirect_stdout(outstring):
+            set_config.create_config_obj(args)
+        result = outstring.getvalue()
+
+        assert result.rstrip('\n') == expected_content


### PR DESCRIPTION
**Description**
Added a --dry-run feature that shows the rendered final text, but doesn't write a file  in set_config, as well as corresponding test. Fixes issue [#158](https://github.com/ufs-community/workflow-tools/issues/158#issue-1595795427).  

<!-- Please provide reference to the issue this pull request is addressing. -->
<!-- For e.g. Fixes #IssueNumber -->

**Type of change**

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

<!-- Please describe the tests that you ran to verify your changes. -->
<!-- Provide instructions so we can reproduce. -->
<!-- Please also list any relevant details for your test configuration -->

<!-- Use the following as a guide to list your tests and delete options that are not relevant. Expand as necessary. -->
<!--
- [x] pytests in GitHub actions.
- [ ] Tests on XYZ OS/HPC/CSP
-->

**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes need updates to the documentation.  I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [x] Any dependent changes have been merged and published

