### PR TITLE
UW-208: As a user, I'd like to see uniform logging for the ins/outs of a whole variety of functions/methods

### DIFF
--- a/src/uwtools/logger.py
+++ b/src/uwtools/logger.py
@@ -205,4 +205,6 @@ def log_decorator(_func=None):
         # Return the pointer to the function
         return log_decorator_wrapper
     # Decorator was called with arguments, so return a decorator function that can read and return a function
-    return log_decorator_info if _func is None else log_decorator_info(_func)
+    if _func is None:
+        return log_decorator_info
+    log_decorator_info(_func)

--- a/src/uwtools/logger.py
+++ b/src/uwtools/logger.py
@@ -3,9 +3,12 @@ Logger
 """
 
 import sys
+import os
 from pathlib import Path
 from typing import Union, List
 import logging
+import functools
+from inspect import getframeinfo, stack
 
 
 class ColoredFormatter(logging.Formatter):
@@ -151,3 +154,50 @@ class Logger:
         handler.setFormatter(logging.Formatter(_format))
 
         return handler
+
+    def log_decorator(self, _func=None):
+        """
+        Add a logger decorator.
+        This decorator will allow setting custom logging details on a given function
+        Decorator based on work by Hima Mahajan https://github.com/hima03/log-decorator
+        """
+        def log_decorator_info(func):
+            @functools.wraps(func)
+            def log_decorator_wrapper(self, *args, **kwargs):
+                #Build logger object
+                logger_obj = Logger.get_logger(self)
+
+                # Create a list of the positional arguments passed to function.
+                # Using repr() for string representation for each argument. repr() is similar to str() with the only
+                # difference being it prints with a pair of quotes and if we calculate a value we get more
+                # precise value than str().
+                args_passed_in_function = [repr(a) for a in args]
+                # Create a list of the keyword arguments. The f-string formats each argument as key=value, where the !r
+                # specifier means that repr() is used to represent the value.
+                kwargs_passed_in_function = [f"{k}={v!r}" for k, v in kwargs.items()]
+
+                # The lists of positional and keyword arguments is joined together to form final string
+                formatted_arguments = ", ".join(args_passed_in_function + kwargs_passed_in_function)
+
+                # Generate file name and function name for calling function. __func.name__ will give the name of the
+                # caller function ie. wrapper_log_info and caller file name ie log-decorator.py
+                #- In order to get actual function and file name we will use 'extra' parameter.
+                #- To get the file name, we are using in-built module inspect.getframeinfo which returns
+                # calling file name
+                py_file_caller = getframeinfo(stack()[1][0])
+                extra_args = { 'func_name_override': func.__name__,
+                           'file_name_override': os.path.basename(py_file_caller.filename) }
+
+                # Before the function execution, log function details."""
+                logger_obj.info(f"Arguments: {formatted_arguments} - Begin function")
+                try:
+                    #log return value from the function
+                    value = func(self, *args, **kwargs)
+                    logger_obj.info(f"Returned: - End function {value!r}", extra=extra_args)
+                except:
+                    #log exception if occurs in function
+                    logger_obj.error(f"Exception: {str(sys.exc_info()[1])}", extra=extra_args)
+                    raise
+                return value
+            return log_decorator_wrapper
+        return log_decorator_info if _func is None else log_decorator_info(_func)

--- a/src/uwtools/logger.py
+++ b/src/uwtools/logger.py
@@ -155,49 +155,54 @@ class Logger:
 
         return handler
 
-    def log_decorator(self, _func=None):
-        """
-        Add a logger decorator.
-        This decorator will allow setting custom logging details on a given function
-        Decorator based on work by Hima Mahajan https://github.com/hima03/log-decorator
-        """
-        def log_decorator_info(func):
-            @functools.wraps(func)
-            def log_decorator_wrapper(self, *args, **kwargs):
-                #Build logger object
-                logger_obj = Logger.get_logger(self)
+def log_decorator(_func=None):
+    """
+    Add a logger decorator.
+    This decorator will allow setting custom logging details on a given function
+    Decorator based on work by Hima Mahajan https://github.com/hima03/log-decorator
+    Recommended wrapper use is to provide caller, local variables and expected output to log
+    """
+    def log_decorator_info(func):
+        @functools.wraps(func)
+        def log_decorator_wrapper(self, *args, **kwargs):
+            #Build logger object
+            logger_obj = Logger.get_logger(self)
 
-                # Create a list of the positional arguments passed to function.
-                # Using repr() for string representation for each argument. repr() is similar to str() with the only
-                # difference being it prints with a pair of quotes and if we calculate a value we get more
-                # precise value than str().
-                args_passed_in_function = [repr(a) for a in args]
-                # Create a list of the keyword arguments. The f-string formats each argument as key=value, where the !r
-                # specifier means that repr() is used to represent the value.
-                kwargs_passed_in_function = [f"{k}={v!r}" for k, v in kwargs.items()]
+            # Create a list of the positional arguments passed to function.
+            # Using repr() for string representation for each argument. repr() is similar to str() with the only
+            # difference being it prints with a pair of quotes and if we calculate a value we get more
+            # precise value than str().
+            args_passed_in_function = [repr(a) for a in args]
+            # Create a list of the keyword arguments. The f-string formats each argument as key=value, where the !r
+            # specifier means that repr() is used to represent the value.
+            kwargs_passed_in_function = [f"{k}={v!r}" for k, v in kwargs.items()]
 
-                # The lists of positional and keyword arguments is joined together to form final string
-                formatted_arguments = ", ".join(args_passed_in_function + kwargs_passed_in_function)
+            # The lists of positional and keyword arguments is joined together to form final string
+            formatted_arguments = ", ".join(args_passed_in_function + kwargs_passed_in_function)
 
-                # Generate file name and function name for calling function. __func.name__ will give the name of the
-                # caller function ie. wrapper_log_info and caller file name ie log-decorator.py
-                #- In order to get actual function and file name we will use 'extra' parameter.
-                #- To get the file name, we are using in-built module inspect.getframeinfo which returns
-                # calling file name
-                py_file_caller = getframeinfo(stack()[1][0])
-                extra_args = { 'func_name_override': func.__name__,
-                           'file_name_override': os.path.basename(py_file_caller.filename) }
+            # Generate file name and function name for calling function. __func.name__ will give the name of the
+            # caller function ie. wrapper_log_info and caller file name ie log-decorator.py
+            #- In order to get actual function and file name we will use 'extra' parameter.
+            #- To get the file name, we are using in-built module inspect.getframeinfo which returns
+            # calling file name
+            # note that unlike the reference code, we will only write to debug level
+            py_file_caller = getframeinfo(stack()[1][0])
+            extra_args = { 'func_name_override': func.__name__,
+                       'file_name_override': os.path.basename(py_file_caller.filename) }
 
-                # Before the function execution, log function details."""
-                logger_obj.info(f"Arguments: {formatted_arguments} - Begin function")
-                try:
-                    #log return value from the function
-                    value = func(self, *args, **kwargs)
-                    logger_obj.info(f"Returned: - End function {value!r}", extra=extra_args)
-                except:
-                    #log exception if occurs in function
-                    logger_obj.error(f"Exception: {str(sys.exc_info()[1])}", extra=extra_args)
-                    raise
-                return value
-            return log_decorator_wrapper
-        return log_decorator_info if _func is None else log_decorator_info(_func)
+            # Before the function execution, log function details."""
+            logger_obj.debug(f"Arguments: {formatted_arguments} - Begin function")
+            try:
+                #log return value from the function
+                value = func(self, *args, **kwargs)
+                logger_obj.debug(f"Returned: - End function {value!r}", extra=extra_args)
+            except:
+                #log exception if occurs in function
+                logger_obj.error(f"Exception: {str(sys.exc_info()[1])}", extra=extra_args)
+                raise
+            # Return function value
+            return value
+        # Return the pointer to the function
+        return log_decorator_wrapper
+    # Decorator was called with arguments, so return a decorator function that can read and return a function
+    return log_decorator_info if _func is None else log_decorator_info(_func)

--- a/src/uwtools/templater.py
+++ b/src/uwtools/templater.py
@@ -88,6 +88,7 @@ def set_template(argv):
 
     logfile = os.path.join(os.path.dirname(__file__), "templater.log")
     log = Logger(level='info',
+        name='templater_log',
         _format='%(message)s',
         colored_log= False,
         logfile_path=logfile
@@ -95,6 +96,7 @@ def set_template(argv):
     if user_args.verbose:
         log.handlers.clear()
         log = Logger(level='debug',
+            name='templater_log',
             _format='%(asctime)s - %(levelname)-8s - %(name)-12s: %(message)s',
             colored_log= True,
             logfile_path=logfile
@@ -103,8 +105,6 @@ def set_template(argv):
     elif user_args.quiet:
         log.handlers.clear()
         log.propagate = False
-
-
 
     log.info(f"""Running script templater.py with args:
 {('-' * 70)}
@@ -154,7 +154,10 @@ def set_template(argv):
         # writing custom logs specific to function, outside of log decorator, if needed
         # provide caller, local variables and expected output to the log
         #pylint: disable=try-except-raise
-        self.log.debug("Templater function custom log, outside decorator")
+
+        # Initializing logger object to write custom logs
+        self.logger_obj = Logger.get_logger(self)
+        self.logger_obj.debug("Templater function custom log, outside decorator")
         try:
             return
         except:

--- a/src/uwtools/templater.py
+++ b/src/uwtools/templater.py
@@ -12,7 +12,7 @@ import argparse
 
 from uwtools.j2template import J2Template
 from uwtools import config
-from uwtools.logger import Logger
+from uwtools.logger import Logger, log_decorator
 
 def dict_from_config_args(args):
     '''Given a list of command line arguments in the form key=value, return a
@@ -148,6 +148,17 @@ def set_template(argv):
     else:
         # write out rendered template to file
         template.dump_file(user_args.outfile)
+
+    @log_decorator()
+    def details(self):
+        # writing custom logs specific to function, outside of log decorator, if needed
+        # provide caller, local variables and expected output to the log
+        #pylint: disable=try-except-raise
+        self.log.debug("Templater function custom log, outside decorator")
+        try:
+            return
+        except:
+            raise
 
 if __name__ == '__main__':
     set_template(sys.argv[1:])

--- a/tests/test_templater.py
+++ b/tests/test_templater.py
@@ -291,3 +291,36 @@ Running script templater.py with args:
     outcome = ''
     # Check that only the correct messages were logged
     assert result == outcome
+
+def test_log_decorator():
+    """Unit test for checking application of the logger decorator"""
+
+    input_file = os.path.join(uwtools_file_base, "fixtures/nml.IN")
+    config_file = os.path.join(uwtools_file_base, "fixtures/fruit_config.yaml")
+    logfile = os.path.join(os.path.dirname(templater.__file__), "templater.log")
+
+    outcome=\
+    """Finished setting up debug file logging in """ + logfile  + """
+Running script templater.py with args:"""
+
+    with tempfile.TemporaryDirectory(dir='.') as tmp_dir:
+        out_file = f'{tmp_dir}/test_render_from_yaml.nml'
+
+        args = [
+             '-i', input_file,
+             '-c', config_file,
+             '-o', out_file,
+             ]
+
+        print("Begin test of logger decorator")
+    # Capture quiet stdout
+#    outstring = io.StringIO()
+#    with redirect_stdout(outstring):
+#        templater.set_template(args).details()
+#    result = outstring.getvalue()
+        templater.set_template(argv).details()
+
+#    lines = zip(outcome.split('\n'), result.split('\n'))
+#    for outcome_line, result_line in lines:
+#        # Check that only the correct messages were logged
+#        assert outcome_line in result_line

--- a/tests/test_templater.py
+++ b/tests/test_templater.py
@@ -310,15 +310,16 @@ Running script templater.py with args:"""
              '-i', input_file,
              '-c', config_file,
              '-o', out_file,
+             '-v'
              ]
 
         print("Begin test of logger decorator")
-    # Capture quiet stdout
-#    outstring = io.StringIO()
-#    with redirect_stdout(outstring):
-#        templater.set_template(args).details()
-#    result = outstring.getvalue()
-        templater.set_template(argv).details()
+        # Capture verbose stdout
+        outstring = io.StringIO()
+        with redirect_stdout(outstring):
+            templater.set_template(args).details()
+        result = outstring.getvalue()
+        print(result)
 
 #    lines = zip(outcome.split('\n'), result.split('\n'))
 #    for outcome_line, result_line in lines:


### PR DESCRIPTION
**Description**

Given: the user provides a debug flag to any logger-enabled tool
When: a logger decorator function has been applied to a called method
Then: information about the caller, local variables, and expected output will be printed to the screen and log file
Completes issue #165 

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**
- [ ] pytests in GitHub actions.
- [ ] Tests on Ubuntu OS


**Checklist**

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes need updates to the documentation.  I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] Any dependent changes have been merged and published

<!-- 
 If there is a co-author attribution:

Update the final commit message (when squashing and merging) to include  `Co-authored-by: name <name@example.com>` (e.g. `Co-authored-by: Jane Doe <jane_doe@example.com>`).  Each co-author must have their own line, and the email address used must be the email address connected with their GitHub account.
-->
