### PR TITLE
Fixed 3 code examples in templater.py documentation

### DIFF
--- a/docs/Users_Guide/working_with_templates.rst
+++ b/docs/Users_Guide/working_with_templates.rst
@@ -124,7 +124,7 @@ And here is the example YAML config file we want to use to update the values in 
 
 To run templater.py with an input template file and a config file::
 
-    python src/uwtools/atparse_to_jinja2.py -i /<path-totemplate>/jinja2template.nml -c /<path-to-config>/example_config.yaml -o <path-to-outfile>/rendered_template.nml
+    python src/uwtools/templater.py -i /<path-totemplate>/jinja2template.nml -c /<path-to-config>/example_config.yaml -o <path-to-outfile>/rendered_template.nml
 
 The rendered template will be updated with the values contained in the config file::
 
@@ -166,7 +166,7 @@ Input file and command line config items
 
 templater.py can be run with an input file and config items provided through the command line by using the config_items flag::
 
-    python src/uwtools/atparse_to_jinja2.py -i /<path-totemplate>/jinja2template.nml config_items NFGRIDS=0, NMGRID=5, FUNIPNT=' T', IOSRV='None', FPNTPROC='None', FGRDPROC=' None'
+    python src/uwtools/templater.py -i /<path-totemplate>/jinja2template.nml NFGRIDS=0, NMGRID=5, FUNIPNT=' T', IOSRV='None', FPNTPROC='None', FGRDPROC=' None'
 
 Rendered template::
 


### PR DESCRIPTION

**Fixed 3 code examples in templater.py documentation**

Two lines in code examples had the wrong program name. One line incorrectly had an extra word in the arguments (config_items).

**Type of change**

Please delete options that are not relevant.

- [X] This change requires a documentation update

**How Has This Been Tested?**

- [X] ran sample code from templater.py documentation on my laptop.

**Checklist**

- [X] My changes need updates to the documentation.  I have made corresponding changes to the documentation

