### PR TITLE
UW-229 Draft: Adding conversion flags

### DIFF
--- a/src/uwtools/set_config.py
+++ b/src/uwtools/set_config.py
@@ -74,17 +74,17 @@ def parse_args(argv):
     )
 
     parser.add_argument(
-        '--convert_input_file',
+        '--input_file_type',
         help='If provided, will convert provided input file to provided file type. Accepts YAML, bash/ini or namelist',
     )
 
     parser.add_argument(
-        '--convert_config_file',
+        '--config_file_type',
         help='If provided, will convert provided config file to provided file type. Accepts YAML, bash/ini or namelist',
     )
 
     parser.add_argument(
-        '--convert_output_file',
+        '--output_file_type',
         help='If provided, will convert provided output file to provided file type. Accepts YAML, bash/ini or namelist',
     )
     return parser.parse_args(argv)
@@ -100,24 +100,8 @@ def create_config_obj(argv):
         )
 
     user_args = parse_args(argv)
-    infile_type = get_file_type(user_args.input_base_file)
-
-    if user_args.convert_input_file:
-
-        inputDepth = user_args.input_base_file.dictionary_depth()
-
-        if user_args.convert_input_file == "yaml":
-            infile_type = ".yaml"
-
-        elif user_args.convert_input_file == 'nml' and inputDepth == 2:
-            infile_type = ".nml"
-
-        elif user_args.convert_input_file == 'ini' and inputDepth <= 2:
-            infile_type = ".ini"
-
-        else:
-            log.info("Conversion failure: input file not compatible with provided type")
-            return
+    
+    infile_type = user_args.input_file_type or get_file_type(user_args.input_base_file)
 
     if infile_type in [".yaml", ".yml"]:
         config_obj = config.YAMLConfig(user_args.input_base_file)
@@ -136,7 +120,7 @@ def create_config_obj(argv):
 
 
     if user_args.config_file:
-        config_file_type = get_file_type(user_args.config_file)
+        config_file_type = user_args.config_file_type or get_file_type(user_args.config_file)
 
         if config_file_type in [".yaml", ".yml"]:
             user_config_obj = config.YAMLConfig(user_args.config_file)
@@ -148,6 +132,14 @@ def create_config_obj(argv):
 
         elif config_file_type == ".nml":
             user_config_obj = config.F90Config(user_args.config_file)
+        
+        if config_file_type != infile_type:
+            config_depth = user_config_obj.dictionary_depth(user_config_obj.data)
+            input_depth = config_obj.dictionary_depth(config_obj.data)
+
+            if input_depth < config_depth:
+                log.info("Set config failure: config object not compatible with input object")
+                return
 
         config_obj.update_values(user_config_obj)
 
@@ -180,18 +172,31 @@ def create_config_obj(argv):
         return
 
     if user_args.outfile:
-        outfile_type = get_file_type(user_args.outfile)
+        outfile_type = user_args.output_file_type or get_file_type(user_args.outfile)
         if outfile_type != infile_type:
             if outfile_type in [".yaml", ".yml"]:
                 out_object = config.YAMLConfig()
             elif outfile_type in [".bash", ".sh", ".ini", ".IN"]:
+                if config_obj.dictionary_depth(config_obj.data) > 2:
+                    log.info("Set config failure: incompatible file types")
                 out_object = config.INIConfig()
             elif outfile_type == ".nml":
+                if config_obj.dictionary_depth(config_obj.data) != 2:
+                    log.info("Set config failure: incompatible file types")
+                    return 
                 out_object = config.F90Config()
             else:
                 out_object = config.FieldTableConfig()
 
             out_object.update(config_obj)
+
+            output_depth = out_object.dictionary_depth(out_object.data)
+            input_depth = config_obj.dictionary_depth(config_obj.data)
+
+            if input_depth > output_depth:
+                log.info("Set config failure: output object not compatible with input object")
+                return
+            
         else: # same type of file as input, no need to convert it
             out_object = config_obj
         out_object.dump_file(user_args.outfile)

--- a/src/uwtools/set_config.py
+++ b/src/uwtools/set_config.py
@@ -72,6 +72,21 @@ def parse_args(argv):
         action='store_true',
         help='If provided, print a list of required configuration settings to stdout',
     )
+
+    parser.add_argument(
+        '--convert_input_file',
+        help='If provided, will convert provided input file to provided file type. Accepts YAML, bash/ini or namelist',
+    )
+
+    parser.add_argument(
+        '--convert_config_file',
+        help='If provided, will convert provided config file to provided file type. Accepts YAML, bash/ini or namelist',
+    )
+
+    parser.add_argument(
+        '--convert_output_file',
+        help='If provided, will convert provided output file to provided file type. Accepts YAML, bash/ini or namelist',
+    )
     return parser.parse_args(argv)
 
 def create_config_obj(argv):
@@ -86,6 +101,23 @@ def create_config_obj(argv):
 
     user_args = parse_args(argv)
     infile_type = get_file_type(user_args.input_base_file)
+
+    if user_args.convert_input_file:
+
+        inputDepth = user_args.input_base_file.dictionary_depth()
+
+        if user_args.convert_input_file == "yaml":
+            infile_type = ".yaml"
+
+        elif user_args.convert_input_file == 'nml' and inputDepth == 2:
+            infile_type = ".nml"
+
+        elif user_args.convert_input_file == 'ini' and inputDepth <= 2:
+            infile_type = ".ini"
+
+        else:
+            log.info("Conversion failure: input file not compatible with provided type")
+            return
 
     if infile_type in [".yaml", ".yml"]:
         config_obj = config.YAMLConfig(user_args.input_base_file)

--- a/tests/fixtures/simple2.cfg
+++ b/tests/fixtures/simple2.cfg
@@ -1,0 +1,8 @@
+scheduler: slurm
+jobname: abcd
+extra_stuff: 12345
+account: user_account
+nodes: 1
+queue: bos
+tasks_per_node: 4
+walltime: 00:01:00

--- a/tests/test_set_config.py
+++ b/tests/test_set_config.py
@@ -405,3 +405,22 @@ Keys that are set to empty:
     salad.appetizer
 """
     assert result == outcome
+
+def test_cfg_to_yaml():
+    input_file = os.path.join(uwtools_file_base, pathlib.Path("fixtures/simple2.cfg"))
+
+    with tempfile.TemporaryDirectory(dir='.') as tmp_dir:
+
+        out_file = f'{tmp_dir}/test.yaml'
+        args = ['-i', input_file, '--dry_run', '--input_file_type', '.yaml']
+
+        outstring = io.StringIO()
+        with redirect_stdout(outstring):
+            set_config.create_config_obj(args)
+        result = outstring.getvalue()
+
+        expected = config.YAMLConfig(input_file)
+        expected_file = f'{tmp_dir}/test.yaml'
+        expected.dump_file(expected_file)
+
+        assert result.rstrip('\n') == str(expected)

--- a/tests/test_set_config.py
+++ b/tests/test_set_config.py
@@ -407,6 +407,7 @@ Keys that are set to empty:
     assert result == outcome
 
 def test_cfg_to_yaml():
+    ''' testing that .cfg file can be used to create a yaml object.'''
     input_file = os.path.join(uwtools_file_base, pathlib.Path("fixtures/simple2.cfg"))
 
     with tempfile.TemporaryDirectory(dir='.') as tmp_dir:


### PR DESCRIPTION
<!--
- - -  I N S T R U C T I O N S  --  P L E A S E  R E A D  - - -
Please remove boiler plate instructions when filling out this template.
Please remove unwanted/unrelated/irrelevant information such as comments provided as a reference in this template.
Use proper formatting to separate code snippets from text description e.g. use ```code block``` or `in-line code`.
Please copy any output files into a Github gist (for e.g.) and link to the gist, rather than relying on paths on platforms that might change or disappear.


-->

**Description**

This is a second check-in to make sure Janet and I are on the right track. Here we've removed the original logic and reworked it with how we understood the requests. Want confirmation before moving too much more forward. 

For issue [#179](https://github.com/ufs-community/workflow-tools/issues/179). 
Add additional CLI args that make the config parser more user friendly. Please reference the [Toolbox MVP](https://confluence-epic.woc.noaa.gov/display/UW/Toolbox+MVP) for specifics.
The "conversion" flag (please choose an appropriate flag name) is meant to allow a user the flexibility to provide say a yaml base config and write out a f90 namelist.
Each of the base, config, and output file types could technically be different file types (Jeez, I hope that folks don't ACTUALLY do THAT regularly). The most common use case might be that we have a base file in f90nml format, the user config in YAML, and the output needs to be either yaml or f90nml.
Tests already exist for these conversions in test_config:: test_transform_config. Reference those tests for how this is implemented.

<!-- Please include relevant motivation and context. -->
<!-- Please include a summary of the change and which issue is fixed. -->
<!-- List any dependencies that are required for this change. -->

<!-- Please provide reference to the issue this pull request is addressing. -->
<!-- For e.g. Fixes #IssueNumber -->

**Type of change**

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

<!-- Please describe the tests that you ran to verify your changes. -->
<!-- Provide instructions so we can reproduce. -->
<!-- Please also list any relevant details for your test configuration -->

<!-- Use the following as a guide to list your tests and delete options that are not relevant. Expand as necessary. -->
<!--
- [ ] pytests in GitHub actions.
- [ ] Tests on XYZ OS/HPC/CSP
-->

**Checklist**

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes need updates to the documentation.  I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] Any dependent changes have been merged and published

<!-- 
 If there is a co-author attribution:

Update the final commit message (when squashing and merging) to include  `Co-authored-by: name <name@example.com>` (e.g. `Co-authored-by: Jane Doe <jane_doe@example.com>`).  Each co-author must have their own line, and the email address used must be the email address connected with their GitHub account.
-->
