### PR TITLE
Bugfix: Add check for return status of the 'make clean html' command; add summary info

### DIFF
--- a/.github/jobs/build_documentation.sh
+++ b/.github/jobs/build_documentation.sh
@@ -8,6 +8,7 @@ DOCS_DIR=${GITHUB_WORKSPACE}/docs
 # run Make to build the documentation and return to previous directory
 cd ${DOCS_DIR}
 make clean html
+status=$?
 cd -
 
 # copy HTML output into directory to create an artifact
@@ -18,8 +19,20 @@ cp -r ${DOCS_DIR}/_build/html/* artifact/documentation
 # Copy it into the artifact and documeentation directories
 # so it will be available in the artifacts
 warning_file=${DOCS_DIR}/_build/warnings.log
-if [ -s $warning_file ]; then
+if [[ $status != 0 || -s $warning_file ]]; then
+  if [ $status != 0 ]; then
+    echo "ERROR: 'make clean html' failed with status $status."
+  fi
   cp -r ${DOCS_DIR}/_build/warnings.log artifact/doc_warnings.log
   cp artifact/doc_warnings.log artifact/documentation
+  echo ERROR: Warnings/Errors found in documentation
+  echo Summary:
+  grep WARNING ${DOCS_DIR}/_build/warnings.log
+  grep ERROR ${DOCS_DIR}/_build/warnings.log
+  grep CRITICAL ${DOCS_DIR}/_build/warnings.log
+  echo Review this log file or download documentation_warnings.log artifact
   exit 1
 fi
+
+echo INFO: Documentation was built successfully.
+


### PR DESCRIPTION
…d summary info

**Description**

Added a check for the return status of the "make html" command in build_documentation.sh and additional summary information.  Currently, the GHA jobs still succeeds since we fail to return bad status from that script.

The issue is linked under Development in the right hand side menu of this PR, but also listed here: Fixes #199 

**Type of change**

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

I did not test this change because warnings/error in the documentation are needed to test.  This same code is running successfully in other repos as demonstrated under the example links in the "Possible Implementation" section of the Issue.

**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas 
- [ ] My changes need updates to the documentation.  I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [ ] Any dependent changes have been merged and published
