### PR TITLE
Update .readthedocs.yaml

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,10 +9,14 @@ version: 2
 #formats: all
 formats: []
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.10"
+
 # Optionally set the version of Python and requirements required to build your
 # docs
 python:
-   version: 3.7
    install:
    - requirements: docs/requirements.txt
 


### PR DESCRIPTION
**Description**
Modify .readthedocs.yaml for the structure of the Python version and update to Python 3.10 to resolve the Import and Extension errors related to urllib3 in ReadTheDocs builds like the one seen here: https://readthedocs.org/projects/unified-workflow/builds/20373544/

There is no issue for this change.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

This has been tested in the METplus repository and it fixes the problem described above.

**Checklist**

- [N/A] My code follows the style guidelines of this project
- [N/A] I have performed a self-review of my own code
- [N/A] I have commented my code, particularly in hard-to-understand areas
- [N/A] My changes need updates to the documentation.  I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [N/A] Any dependent changes have been merged and published

