### PR TITLE
Remove realpath, pin condev version in README.md

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ METAJSON    = $(RECIPE_DIR)/meta.json
 RECIPEFILES = $(addprefix $(RECIPE_DIR)/,conda_build_config.yaml meta.yaml)
 TARGETS     = devshell env format lint meta package test typecheck unittest
 
-export RECIPE_DIR := $(shell realpath ./recipe)
+export RECIPE_DIR := $(shell cd ./recipe && pwd)
 
 spec = $(call val,name)$(2)$(call val,version)$(2)$(call val,$(1))
 val  = $(shell jq -r .$(1) $(METAJSON))

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ bash Miniforge3-Linux-aarch64.sh -bfp ~/conda
 rm Miniforge3-Linux-aarch64.sh
 source ~/conda/etc/profile.d/conda.sh
 conda activate
-conda install -y -c maddenp condev
+conda install -y -c maddenp condev=0.4.0
 cd /to/your/workflow-tools/clone
 make devshell
 ```

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -3,6 +3,6 @@ channels:
   - conda-forge
   - maddenp
 dependencies:
-  - condev=0.3.0
+  - condev=0.4.0
   - sphinx-gallery
   - sphinxcontrib-bibtex

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -62,7 +62,7 @@ unittest() {
   msg OK
 }
 
-test "${CONDA_BUILD:-}" = 1 && cd ../test_files || cd $(realpath $(dirname $0)/../src)
+test "${CONDA_BUILD:-}" = 1 && cd ../test_files || cd $(dirname $0)/../src
 msg Running in $PWD
 if [[ -n "${1:-}" ]]; then
   # Run single specified code-quality tool.


### PR DESCRIPTION
Two trivial updates:

1. Replace calls to `realpath`, which I have discovered is not available by default under OSX (but is under GNU/Linux) with more portable calls. This is in response to a couple OSX users on our team experiencing difficulties, which they solved by doing `homebrew install coreutils`, an easy workaround it would nevertheless be better to avoid having to rely on.
2. Pin `condev` (once in an executable-code context, once in a documentation context) to a specific version known to be compatible with the current `uwtools` codebase, to insulate the latter from unexpected upstream changes.

I'll happily accept a quick LGTM review from anyone.