### PR TITLE
j2template-module-fixup

### DIFF
--- a/src/uwtools/j2template.py
+++ b/src/uwtools/j2template.py
@@ -30,7 +30,7 @@ class J2Template:
         :param template_str: An in-memory Jinja2 template.
         :raises RuntimeError: If neither a template file or path is provided.
         """
-        self._log = logging.getLogger(kwargs.get("log_name"))
+        self.log = logging.getLogger(kwargs.get("log_name"))
         self._configure_obj = configure_obj
         self._template_path = template_path
         self._template_str = template_str
@@ -51,7 +51,7 @@ class J2Template:
         :param output_path: Path to file to write.
         """
         msg = f"Writing rendered template to output file: {output_path}"
-        self._log.debug(msg)
+        self.log.debug(msg)
         with open(output_path, "w+", encoding="utf-8") as file_:
             print(self.render_template(), file=file_)
 

--- a/src/uwtools/j2template.py
+++ b/src/uwtools/j2template.py
@@ -1,64 +1,20 @@
 """
-Template classes.
+Support for handling Jinja2 templates.
 """
 
 import logging
 import os
-from typing import Optional
+from typing import List, Optional, Set
 
-from jinja2 import BaseLoader, Environment, FileSystemLoader, meta
+from jinja2 import BaseLoader, Environment, FileSystemLoader, Template, meta
 
 from uwtools import logger
 
 
-def register_filters(j2env):
-    """
-    Given a Jinja2 environment, register a set of filters recognized by the UW Tools parser.
-    """
-
-    j2env.filters["path_join"] = path_join
-
-
-def path_join(arg):
-    """
-    A Jinja2 filter definition for joining paths.
-    """
-    return os.path.join(*arg)
-
-
 class J2Template:
     """
-    This class reads in Jinja templates from files or strings, and renders the template given the
-    user-provided configuration object.
-
-    Attributes
-    ----------
-
-    configure_obj : dict
-        The key/value pairs needed to fill in the provided template.
-        Defaults to the user's shell environment.
-
-    template
-        Jinja2 template object
-
-    undeclared_variables : list
-        List of variables needed given a Jinja2 template
-
-    Methods
-    -------
-
-    _load_file()
-        Wrapper around loading a Jinja2 template from a file.
-
-    _load_string()
-        Wrapper around loading a Jinja2 template from a string
-
-    dump_file(output_path)
-        Wrapper around writing the template to an output path
-
-    validate_config()
-        Checks to ensure that the provided configure_obj is sufficient
-        to meet the needs of the undeclared_variables in the template
+    Reads Jinja templates from files or strings, and renders them using the user-provided
+    configuration object.
     """
 
     def __init__(
@@ -69,98 +25,105 @@ class J2Template:
         **kwargs,
     ) -> None:
         """
-        Parameters
-        ----------
-        configure_obj
-            See class-level docstring
-        template_path
-            Path to a Jinja2 template file
-        template_str
-            A Jinja2 template
-
-        Keyword Arguments
-        -----------------
-        loader_args : dict
-            A dictionary of arguments to pass to the J2 loader
-        log_name : str
-            The name of the logging object to be used.
+        :param configure_obj: Key/value pairs needed to render the provided template.
+        :param template_path: Path to a Jinja2 template file.
+        :param template_str: An in-memory Jinja2 template.
+        :raises RuntimeError: If neither a template file or path is provided.
         """
-
-        self.log = logging.getLogger(kwargs.get("log_name"))
-
-        self.configure_obj = configure_obj
-        self.template_path = template_path
-        self.template_str = template_str
-        self.loader_args = kwargs.get("loader_args", {})
-
+        self._log = logging.getLogger(kwargs.get("log_name"))
+        self._configure_obj = configure_obj
+        self._template_path = template_path
+        self._template_str = template_str
+        self._loader_args = kwargs.get("loader_args", {})
         if template_path is not None:
-            self.template = self._load_file(template_path)
+            self._template = self._load_file(template_path)
         elif template_str is not None:
-            self.template = self._load_string(template_str)
+            self._template = self._load_string(template_str)
         else:
             raise RuntimeError("Must provide either a template path or a template string")
+
+    # Public methods
 
     def dump_file(self, output_path: str) -> None:
         """
         Write rendered template to the path provided.
 
-        Parameters
-        ----------
-        output_path
-            Path to file to write
+        :param output_path: Path to file to write.
         """
         msg = f"Writing rendered template to output file: {output_path}"
-        self.log.debug(msg)
+        self._log.debug(msg)
         with open(output_path, "w+", encoding="utf-8") as file_:
             print(self.render_template(), file=file_)
 
-    @logger.verbose()
-    def _load_file(self, template_path):
-        """
-        Load the Jinja2 template from the file provided.
-
-        Returns
-        -------
-        Jinja2 Template object
-        """
-
-        self._j2env = Environment(loader=FileSystemLoader(searchpath="/"))
-        register_filters(self._j2env)
-        return self._j2env.get_template(template_path)
-
-    @logger.verbose()
-    def _load_string(self, template_str):
-        """
-        Load the Jinja2 template from the string provided.
-
-        Returns
-        -------
-        Jinja2 Template object
-        """
-
-        self._j2env = Environment(loader=BaseLoader(), **self.loader_args)
-        register_filters(self._j2env)
-        return self._j2env.from_string(template_str)
-
-    def render_template(self):
+    def render_template(self) -> str:
         """
         Render the Jinja2 template so that it's available in memory.
 
-        Returns
-        -------
-        A string containing a rendered Jinja2 template.
+        :return A string containing a rendered Jinja2 template.
         """
-        return self.template.render(self.configure_obj)
+        return self._template.render(self._configure_obj)
 
     @property
-    def undeclared_variables(self):
+    def undeclared_variables(self) -> Set[str]:
         """
-        Generates a list of variables needed for self.template.
+        Returns the names of variables needed to render the template.
+
+        :return Names of variables needed to render the template.
         """
-        if self.template_str is not None:
-            j2_parsed = self._j2env.parse(self.template_str)
+        if self._template_str is not None:
+            j2_parsed = self._j2env.parse(self._template_str)
         else:
-            assert self.template_path is not None
-            with open(self.template_path, encoding="utf-8") as file_:
+            assert self._template_path is not None
+            with open(self._template_path, encoding="utf-8") as file_:
                 j2_parsed = self._j2env.parse(file_.read())
         return meta.find_undeclared_variables(j2_parsed)
+
+    # Private methods
+
+    @logger.verbose()
+    def _load_file(self, template_path: str) -> Template:
+        """
+        Load the Jinja2 template from the file provided.
+
+        :param template_path: Filesystem path to the Jinja2 template file. :return The Jinja2
+            template object.
+        """
+        self._j2env = Environment(loader=FileSystemLoader(searchpath="/"))
+        _register_filters(self._j2env)
+        return self._j2env.get_template(template_path)
+
+    @logger.verbose()
+    def _load_string(self, template: str) -> Template:
+        """
+        Load the Jinja2 template from the string provided.
+
+        :param template: An in-memory Jinja2 template. :return The Jinja2 template object.
+        """
+        self._j2env = Environment(loader=BaseLoader(), **self._loader_args)
+        _register_filters(self._j2env)
+        return self._j2env.from_string(template)
+
+
+# Public functions
+
+
+def path_join(path_components: List[str]) -> str:
+    """
+    A Jinja2 filter definition for joining paths.
+
+    :param path_components: The filesystem path components to join into a single path. :return The
+        joined path
+    """
+    return os.path.join(*path_components)
+
+
+# Private functions
+
+
+def _register_filters(j2env: Environment) -> None:
+    """
+    Register a set of filters with a Jinja2 Environment.
+
+    :param j2env: The Jinja2 Environment with which to register filters.
+    """
+    j2env.filters["path_join"] = path_join

--- a/src/uwtools/tests/test_j2template.py
+++ b/src/uwtools/tests/test_j2template.py
@@ -1,4 +1,4 @@
-# pylint: disable=missing-function-docstring,redefined-outer-name
+# pylint: disable=missing-function-docstring,protected-access,redefined-outer-name
 """
 Tests for uwtools.j2template module.
 """
@@ -19,8 +19,8 @@ def testdata():
 
 
 def validate(template):
-    assert template.configure_obj.get("greeting") == "Hello"
-    assert template.configure_obj.get("recipient") == "the world"
+    assert template._configure_obj.get("greeting") == "Hello"
+    assert template._configure_obj.get("recipient") == "the world"
     assert template.render_template() == "Hello to the world"
     assert template.undeclared_variables == {"greeting", "recipient"}
 


### PR DESCRIPTION
**Description**

While working on the modal CLI, I discovered that this module could use some code-quality cleanup. This might happen in some other modules that interact with the CLI (and with unit tests that also need to be updated) so I thought that, rather than doing one big PR, I could do smaller PRs with some of the preparatory work to keep the changes more isolated and easier to understand.

This PR updates the `uwtools.j2template` module with:

- Delegation of `J2Template` class-level docstring information to the class method docstrings
- Addition of missing type annotations in methods and functions
- Addition of param/return/raises annotations in method/function docstrings
- A separation (both via in-module code organization and function/method/variable names) of public and private members

With the exception of naming updates for now-private members, all existing unit tests pass without modification, so this is functionally a no-op.

**How Has This Been Tested?**

Passes `make test` in a dev shell and GitHub Actions.

**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes need updates to the documentation.  I have made corresponding changes to the documentation **NA**
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [ ] Any dependent changes have been merged and published **NA**
