### PR TITLE
UW-272 Develop unit tests that verify and validate that the Rocoto XML generator outputs a valid Rocoto XML

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,6 +18,7 @@ requirements:
     - python >=3.8,<3.12
     - python {{ release }}
     - pyyaml 6.0.*
+    - lxml 4.9.*
 test:
   requires:
     - black 23.3.*

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,10 +15,10 @@ requirements:
     - f90nml 1.4.*
     - jinja2 3.0.*
     - jsonschema 4.17.*
+    - lxml 4.9.*
     - python >=3.8,<3.12
     - python {{ release }}
     - pyyaml 6.0.*
-    - lxml 4.9.*
 test:
   requires:
     - black 23.3.*

--- a/src/pyproject.toml
+++ b/src/pyproject.toml
@@ -39,6 +39,11 @@ disable = [
   "unnecessary-lambda-assignment",
   "use-dict-literal",
 ]
+
+extension-pkg-allow-list = [
+  "lxml",
+]
+
 recursive = true
 
 [tool.pytest.ini_options]

--- a/src/uwtools/resources/schema_with_metatasks.rng
+++ b/src/uwtools/resources/schema_with_metatasks.rng
@@ -1,3 +1,4 @@
+<!-- Copied from the Rocoto repository at release version 1.3.5.-->
 <grammar xmlns="http://relaxng.org/ns/structure/1.0" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
                                                                       
   <start>

--- a/src/uwtools/resources/schema_with_metatasks.rng
+++ b/src/uwtools/resources/schema_with_metatasks.rng
@@ -1,0 +1,622 @@
+<grammar xmlns="http://relaxng.org/ns/structure/1.0" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+                                                                      
+  <start>
+
+    <element name="workflow">
+
+      <!-- Realtime workflow attribute is required-->
+      <attribute name="realtime">
+        <choice>
+          <value>f</value>
+          <value>F</value>
+          <value>false</value>
+          <value>False</value>
+          <value>FALSE</value>
+          <value>t</value>
+          <value>T</value>
+          <value>true</value>
+          <value>True</value>
+          <value>TRUE</value>
+        </choice>
+      </attribute>
+
+      <!-- scheduler workflow attribute is required and must be one of the values listed -->
+      <attribute name="scheduler">
+        <choice>
+          <value>sge</value>
+          <value>lsf</value>
+          <value>lsfcray</value>
+          <value>ll</value>
+          <value>moab</value>
+          <value>moabtorque</value>
+          <value>torque</value>
+          <value>pbspro</value>
+          <value>slurm</value>
+          <value>cobalt</value>
+        </choice>
+      </attribute>
+
+      <!-- cyclethrottle workflow attribute is optional and must be a non negative integer -->
+      <optional>
+        <attribute name="cyclethrottle">
+          <data type="nonNegativeInteger"/>
+        </attribute>
+      </optional>
+
+      <!-- taskthrottle workflow attribute is optional and must be a non negative integer -->
+      <optional>
+        <attribute name="taskthrottle">
+          <data type="nonNegativeInteger"/>
+        </attribute>
+      </optional>
+
+      <!-- corethrottle workflow attribute is optional and must be a non negative integer -->
+      <optional>
+        <attribute name="corethrottle">
+          <data type="nonNegativeInteger"/>
+        </attribute>
+      </optional>
+
+      <!-- duthrottle workflow attribute is optional and must be a non negative integer -->
+      <optional>
+        <attribute name="duthrottle">
+          <data type="nonNegativeInteger"/>
+        </attribute>
+      </optional>
+
+      <!-- cyclelifespan workflow attribute is optional and must be a nonNegativeTime defined below-->
+      <optional>
+        <attribute name="cyclelifespan">
+          <ref name="nonNegativeTime"/>
+        </attribute>
+      </optional>
+
+      <!-- Order of log, cycle, task, and metatask tags does not matter -->
+      <interleave>
+
+        <!-- Must have exactly one log tag -->
+        <element name="log">
+          <optional>
+            <attribute name="verbosity">
+              <data type="nonNegativeInteger"/>
+            </attribute>
+          </optional>
+          <ref name="compoundTimeString"/>
+        </element>
+
+        <!-- Must have at least one cycledef tag -->
+        <oneOrMore>
+          <element name="cycledef">
+            <!-- group attribute is optional and must be a string -->
+            <optional>
+              <attribute name="group">
+                <data type="string"/>
+              </attribute>
+            </optional>
+            <optional>
+              <attribute name="activation_offset">
+                <ref name="time"/>
+              </attribute>
+            </optional>
+            <choice>
+              <list>
+                <ref name="cronField"/>
+                <ref name="cronField"/>
+                <ref name="cronField"/>
+                <ref name="cronField"/>
+                <ref name="cronField"/>
+                <ref name="cronField"/>
+              </list>
+              <list>
+                <ref name="YYYYMMDDHHMM"/>
+                <ref name="YYYYMMDDHHMM"/>
+                <ref name="nonNegativeTime"/>
+              </list>
+              <list>
+                <ref name="YYYYMMDDHHMM"/>
+                <ref name="nonNegativeTime"/>
+                <ref name="nonNegativeTime"/>
+              </list>
+            </choice>
+          </element>
+        </oneOrMore>
+
+        <!-- Must have at least one task or metatask tag.  Task tags must follow log and cycle tags -->
+        <oneOrMore>
+          <choice>
+            <ref name="task"/>
+            <ref name="metatask"/>
+          </choice>
+        </oneOrMore>
+
+      </interleave>
+
+    </element>  
+
+  </start>
+
+  <!-- Type definitions -->
+
+  <define name="rb_or_sh">
+    <choice>
+      <element name="rb">
+        <optional>
+          <attribute name="name">
+            <data type="string"/>
+          </attribute>
+        </optional>
+        <ref name="compoundTimeString"/>
+      </element>
+
+      <element name="sh">
+        <optional>
+          <attribute name="name">
+            <data type="string"/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="shell">
+            <data type="string"/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="runopt">
+            <data type="string"/>
+          </attribute>
+        </optional>
+        <ref name="compoundTimeString"/>
+      </element>
+    </choice>
+  </define>
+
+  <define name="nonNegativeTime">
+    <choice>
+      <data type="string"><param name="pattern">\s*(\d+|(#[^#\s]+#))+\s*</param></data>
+      <data type="string"><param name="pattern">\s*(\d+|(#[^#\s]+#))+:(\d+|(#[^#\s]+#))+\s*</param></data>
+      <data type="string"><param name="pattern">\s*(\d+|(#[^#\s]+#))+:(\d+|(#[^#\s]+#))+:(\d+|(#[^#\s]+#))+\s*</param></data>
+      <data type="string"><param name="pattern">\s*(\d+|(#[^#\s]+#))+:(\d+|(#[^#\s]+#))+:(\d+|(#[^#\s]+#))+:(\d+|(#[^#\s]+#))+\s*</param></data>
+    </choice>
+  </define>
+
+  <define name="time">
+    <choice>
+      <data type="string"><param name="pattern">\s*-?(\d+|(#[^#\s]+#))+\s*</param></data>
+      <data type="string"><param name="pattern">\s*-?(\d+|(#[^#\s]+#))+:(\d+|(#[^#\s]+#))+\s*</param></data>
+      <data type="string"><param name="pattern">\s*-?(\d+|(#[^#\s]+#))+:(\d+|(#[^#\s]+#))+:(\d+|(#[^#\s]+#))+\s*</param></data>
+      <data type="string"><param name="pattern">\s*-?(\d+|(#[^#\s]+#))+:(\d+|(#[^#\s]+#))+:(\d+|(#[^#\s]+#))+:(\d+|(#[^#\s]+#))+\s*</param></data>
+    </choice>
+  </define>
+
+
+  <define name="YYYYMMDDHHMM">
+    <data type="string"><param name="pattern">\s*\d\d\d\d\d\d\d\d\d\d\d\d\s*</param></data>
+  </define>
+
+  <define name="cronField">
+    <choice>
+      <data type="string"><param name="pattern">\*</param></data>
+      <data type="string"><param name="pattern">\*/\d+</param></data>
+      <data type="string"><param name="pattern">(\d+|\d+-\d+|\d+-\d+/\d+)(,\d+|,\d+-\d+|,\d+-\d+/\d+)*</param></data>
+    </choice>
+  </define>
+
+  <define name="compoundTimeString">
+    <oneOrMore>
+      <choice>
+        <text/>
+        <element name="cyclestr"><optional><attribute name="offset"><ref name="time"/></attribute></optional><text/></element>
+      </choice>
+    </oneOrMore>
+  </define>
+
+  <define name="nameValuePair">
+    <interleave>
+      <element name="name">
+        <ref name="compoundTimeString"/>
+      </element>
+      <optional>
+        <element name="value">
+          <ref name="compoundTimeString"/>
+        </element>                    
+      </optional>
+    </interleave>
+  </define>
+
+  <define name="dependency_tree">
+    <choice>
+      <element name="taskdep">
+        <attribute name="task">
+          <data type="string"/>          
+        </attribute>
+        <optional>
+          <attribute name="cycle_offset">
+            <ref name="time"/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="state">
+            <choice>
+	      <value>RUNNING</value>
+	      <value>Running</value>
+	      <value>running</value>
+	      <value>SUCCEEDED</value>
+              <value>DEAD</value>
+	      <value>Succeeded</value>
+              <value>Dead</value>
+	      <value>succeeded</value>
+              <value>dead</value>
+            </choice>
+          </attribute>
+        </optional>
+        <empty/>
+      </element>
+      <ref name="rb_or_sh"/>
+      <element name="true">
+        <empty/>
+      </element>
+      <element name="false">
+        <empty/>
+      </element>
+      <element name="streq">
+        <element name="left">
+          <ref name="compoundTimeString"/>
+        </element>
+        <element name="right">
+          <ref name="compoundTimeString"/>
+        </element>
+      </element>
+      <element name="strneq">
+        <element name="left">
+          <ref name="compoundTimeString"/>
+        </element>
+        <element name="right">
+          <ref name="compoundTimeString"/>
+        </element>
+      </element>
+      <element name="cycleexistdep">
+        <attribute name="cycle_offset">
+          <ref name="time"/>
+        </attribute>
+        <empty/>
+      </element>
+      <element name="taskvalid">
+        <attribute name="task">
+          <data type="string"/>
+        </attribute>
+        <empty/>
+      </element>
+      <element name="metataskdep">
+        <attribute name="metatask">
+          <data type="string"/>          
+        </attribute>
+        <optional>
+          <attribute name="cycle_offset">
+            <ref name="time"/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="state">
+            <choice>
+	      <value>SUCCEEDED</value>
+              <value>DEAD</value>
+	      <value>Succeeded</value>
+              <value>Dead</value>
+	      <value>succeeded</value>
+              <value>dead</value>
+            </choice>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="threshold">
+            <data type="float"><param name="minInclusive">0.0</param><param name="maxInclusive">1.0</param></data>
+          </attribute>
+        </optional>
+        <empty/>
+      </element>
+      <element name="datadep">
+        <optional>
+          <attribute name="age">
+            <ref name="nonNegativeTime"/>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="minsize">
+            <data type="string"/>
+          </attribute>
+        </optional>
+        <ref name="compoundTimeString"/>
+      </element>
+      <element name="timedep">
+        <ref name="compoundTimeString"/>
+      </element>
+      <element name="not">
+        <ref name="dependency_tree"/>
+      </element>
+      <element name="and">
+        <oneOrMore>
+          <ref name="dependency_tree"/>
+        </oneOrMore>
+      </element>
+      <element name="or">
+        <oneOrMore>
+          <ref name="dependency_tree"/>
+        </oneOrMore>
+      </element>
+      <element name="nor">
+        <oneOrMore>
+          <ref name="dependency_tree"/>
+        </oneOrMore>
+      </element>
+      <element name="xor">
+        <oneOrMore>
+          <ref name="dependency_tree"/>
+        </oneOrMore>
+      </element>
+      <element name="nand">
+        <oneOrMore>
+          <ref name="dependency_tree"/>
+        </oneOrMore>
+      </element>
+      <element name="some">
+        <attribute name="threshold">
+            <data type="float"><param name="minInclusive">0.0</param><param name="maxInclusive">1.0</param></data>
+        </attribute>
+        <oneOrMore>
+          <ref name="dependency_tree"/>
+        </oneOrMore>
+      </element>
+    </choice>
+  </define>
+
+  <define name="task">
+    <element name="task">
+
+      <!-- Exactly one task name attribute -->
+      <attribute name="name">
+        <data type="string"/>          
+      </attribute>
+
+      <!-- Optional task maxtries attribute -->
+      <optional>
+        <attribute name="maxtries">
+          <data type="positiveInteger"/>          
+        </attribute>
+      </optional>
+
+      <!-- Optional task throttle attribute -->
+      <optional>
+        <attribute name="throttle">
+          <data type="positiveInteger"/>          
+        </attribute>
+      </optional>
+
+      <!-- Optional task cycledefs attribute -->
+      <optional>
+        <attribute name="cycledefs">
+          <data type="string"/>          
+        </attribute>
+      </optional>
+
+      <!-- Optional task final attribute -->
+      <optional>
+        <attribute name="final">
+          <choice>
+            <value>f</value>
+            <value>F</value>
+            <value>false</value>
+            <value>False</value>
+            <value>FALSE</value>
+            <value>t</value>
+            <value>T</value>
+            <value>true</value>
+            <value>True</value>
+            <value>TRUE</value>
+ 	  </choice>
+        </attribute>
+      </optional>
+
+      <!-- Order of task property tags does not matter -->
+      <interleave>
+
+	<!-- Optional shared or exclusive tag -->
+	<optional>
+          <choice>
+            <element name="shared">
+	      <data type="string"/>
+	    </element>
+            <element name="exclusive">
+	      <data type="string"/>
+	    </element>
+	  </choice>
+	</optional>
+
+        <!-- Rewind tag is optional -->
+        <optional>
+          <element name="rewind">
+            <oneOrMore>
+              <ref name="rb_or_sh"/>
+            </oneOrMore>
+          </element>
+        </optional>
+
+        <!-- Exactly one command tag -->
+        <element name="command">
+          <ref name="compoundTimeString"/>
+        </element>
+
+        <!-- Zero or one account tag -->
+        <optional>
+          <element name="account">
+            <data type="string"/>          
+          </element>
+        </optional>
+
+        <!-- Zero or one queue tag -->
+        <optional>
+          <element name="queue">
+            <data type="string"/>          
+          </element>
+        </optional>
+
+        <!-- Zero or one partition tag -->
+        <optional>
+          <element name="partition">
+            <data type="string"/>
+          </element>
+        </optional>
+
+        <!-- Either one cores tag or one nodes tag is required-->
+        <choice>
+	    <element name="cores">
+	      <data type="positiveInteger"/>
+	    </element>
+	    <element name="nodes">
+	      <data type="string"/>
+	    </element>
+	</choice>
+
+        <!-- Zero or more native tags -->
+	<zeroOrMore>
+	  <element name="native">
+	    <ref name="compoundTimeString"/>
+	  </element>
+	</zeroOrMore>
+
+        <!-- One walltime tag -->
+        <element name="walltime">
+          <ref name="nonNegativeTime"/>
+        </element>
+
+        <!-- Zero or one memory tag -->
+        <optional>
+          <element name="memory">
+            <data type="string"/>          
+          </element>
+        </optional>
+
+        <!-- Zero or one join, stdout, stderr tags -->
+        <!-- NOTE: join tag cannot be combined with either stdout or stderr tags -->
+        <optional>
+          <choice>
+            <optional>
+              <interleave>
+                <optional>
+                  <element name="stdout">
+                    <ref name="compoundTimeString"/>
+                  </element>
+                </optional>
+                <optional>
+                  <element name="stderr">
+                    <ref name="compoundTimeString"/>
+                  </element>
+                </optional>
+              </interleave>
+            </optional>
+            <element name="join">
+              <ref name="compoundTimeString"/>
+            </element>
+          </choice>
+        </optional>
+
+        <!-- Zero or one jobname tag -->
+        <optional>
+          <element name="jobname">
+            <ref name="compoundTimeString"/>
+          </element>
+        </optional>
+
+        <!-- Optional nodesize tag -->
+        <optional>
+          <element name="nodesize">
+            <ref name="compoundTimeString"/>
+          </element>
+        </optional>
+
+        <!-- Zero or more envar tags -->
+        <optional>
+          <oneOrMore>
+            <element name="envar">
+              <ref name="nameValuePair"/>
+            </element>
+          </oneOrMore>
+        </optional>
+
+        <!-- Zero or one dependency tag -->
+        <optional>
+          <element name="dependency">
+            <ref name="dependency_tree"/>   
+          </element>
+        </optional>
+
+        <!-- Zero or one deadline tag -->
+        <optional>
+          <element name="deadline">
+            <ref name="compoundTimeString"/>
+          </element>
+        </optional>
+
+        <!-- Zero or one hangdependency tag -->
+        <optional>
+          <element name="hangdependency">
+            <ref name="dependency_tree"/>   
+          </element>
+        </optional>
+
+      </interleave>
+
+    </element>
+  </define>
+
+
+  <define name="metatask">
+    <element name="metatask">
+
+      <!-- Optional metatask name attribute -->
+      <optional>
+        <attribute name="name">
+          <data type="string"/>          
+        </attribute>
+      </optional>
+
+      <!-- Optional metatask mode attribute -->
+      <optional>
+        <attribute name="mode">
+          <data type="string"/>          
+        </attribute>
+      </optional>
+
+      <!-- Optional metatask throttle attribute -->
+      <optional>
+        <attribute name="throttle">
+          <data type="positiveInteger"/>
+        </attribute>
+      </optional>
+
+      <!-- Order of metatask contents does not matter -->
+      <interleave>
+
+	<!-- Metatasks must have at least one var tag -->
+	<oneOrMore>
+	  <element name="var">
+	    <!-- Each var tag must have the id attribute set -->
+	    <attribute name="name">
+	      <data type="string"/>
+	    </attribute>
+	    <text/>
+	  </element>
+	</oneOrMore>
+
+	<!-- Each metatask must contain at least one metatask or task -->
+	<oneOrMore>
+	  <choice>
+	    <ref name="metatask"/>
+	    <ref name="task"/>
+	  </choice>
+	</oneOrMore>
+
+      </interleave>
+
+    </element>
+  </define>
+
+</grammar>

--- a/src/uwtools/tests/fixtures/rocoto_invalid.xml
+++ b/src/uwtools/tests/fixtures/rocoto_invalid.xml
@@ -5,7 +5,9 @@
 
 ]>
 <workflow realtime="False" scheduler="slurm" >
-
+  <!-- cycledef tag is required to pass validation for a Rocoto schema
+  cycledef defines the set of cycles to be run for the workflow
+  -->
   <log>/some/path/to/&FOO;</log>
   
   <task name="hello" cycledefs="howdy" maxtries="2" >

--- a/src/uwtools/tests/fixtures/rocoto_invalid.xml
+++ b/src/uwtools/tests/fixtures/rocoto_invalid.xml
@@ -5,8 +5,8 @@
 
 ]>
 <workflow realtime="False" scheduler="slurm" >
-  <!-- cycldef tag has been intentionally been removed to fail Rocoto schema validation
-  cycledef defines the set of cycles to be run for the workflow
+  <!-- cycldef tag has intentionally been removed to fail Rocoto schema validation
+  cycledef is required and defines the set of cycles to be run for the workflow
   -->
   <log>/some/path/to/&FOO;</log>
   

--- a/src/uwtools/tests/fixtures/rocoto_invalid.xml
+++ b/src/uwtools/tests/fixtures/rocoto_invalid.xml
@@ -5,7 +5,7 @@
 
 ]>
 <workflow realtime="False" scheduler="slurm" >
-  <!-- cycldef tag has been intentionally been removed to fail validation of Rocoto schema
+  <!-- cycldef tag has been intentionally been removed to fail Rocoto schema validation
   cycledef defines the set of cycles to be run for the workflow
   -->
   <log>/some/path/to/&FOO;</log>

--- a/src/uwtools/tests/fixtures/rocoto_invalid.xml
+++ b/src/uwtools/tests/fixtures/rocoto_invalid.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE workflow [
+  <!ENTITY ACCOUNT "myaccount">
+  <!ENTITY FOO "test.log">
+
+]>
+<workflow realtime="False" scheduler="slurm" >
+
+  <log>/some/path/to/&FOO;</log>
+  
+  <task name="hello" cycledefs="howdy" maxtries="2" >
+    <account>&ACCOUNT;</account>
+    <command>echo hello $person</command>
+    <jobname>hello</jobname>
+    <nodes>1:ppn=1</nodes>
+    <walltime>00:01:00</walltime>
+
+    
+    <envar><name>person</name><value>siri</value></envar>
+
+    
+  </task>
+  
+  <metatask name="ensemble_hello" >
+    
+    <var name="member">foo bar baz</var>
+      
+    <task name="hello_#member#" cycledefs="howdy" maxtries="1" >
+      <account>&ACCOUNT;</account>
+      <command>echo hello #member#</command>
+      <nodes>1:ppn=1</nodes>
+      <walltime>00:01:00</walltime>
+      <jobname>hello_#member#</jobname>
+
+      
+
+      <dependency>
+        <taskdep task="hello"/>
+      </dependency>
+    </task>
+  </metatask>
+
+</workflow>

--- a/src/uwtools/tests/fixtures/rocoto_invalid.xml
+++ b/src/uwtools/tests/fixtures/rocoto_invalid.xml
@@ -10,36 +10,4 @@
   -->
   <log>/some/path/to/&FOO;</log>
   
-  <task name="hello" cycledefs="howdy" maxtries="2" >
-    <account>&ACCOUNT;</account>
-    <command>echo hello $person</command>
-    <jobname>hello</jobname>
-    <nodes>1:ppn=1</nodes>
-    <walltime>00:01:00</walltime>
-
-    
-    <envar><name>person</name><value>siri</value></envar>
-
-    
-  </task>
-  
-  <metatask name="ensemble_hello" >
-    
-    <var name="member">foo bar baz</var>
-      
-    <task name="hello_#member#" cycledefs="howdy" maxtries="1" >
-      <account>&ACCOUNT;</account>
-      <command>echo hello #member#</command>
-      <nodes>1:ppn=1</nodes>
-      <walltime>00:01:00</walltime>
-      <jobname>hello_#member#</jobname>
-
-      
-
-      <dependency>
-        <taskdep task="hello"/>
-      </dependency>
-    </task>
-  </metatask>
-
 </workflow>

--- a/src/uwtools/tests/fixtures/rocoto_invalid.xml
+++ b/src/uwtools/tests/fixtures/rocoto_invalid.xml
@@ -5,7 +5,7 @@
 
 ]>
 <workflow realtime="False" scheduler="slurm" >
-  <!-- cycledef tag is required to pass validation for a Rocoto schema
+  <!-- cycldef tag has been intentionally been removed to fail validation of Rocoto schema
   cycledef defines the set of cycles to be run for the workflow
   -->
   <log>/some/path/to/&FOO;</log>

--- a/src/uwtools/tests/test_rocoto.py
+++ b/src/uwtools/tests/test_rocoto.py
@@ -56,11 +56,14 @@ def test_write_rocoto_xml(tmp_path):
 
 
 def test_rocoto_xml_is_valid():
-    input_xml = support.fixture_path("hello_workflow.xml")
-    tree = etree.parse(input_xml)
-    root = etree.tostring(tree.getroot())
-
-    breakpoint()
     with resources.as_file(resources.files("uwtools.resources")) as resc:
-        relaxng_doc = str(resc / "schema_with_metatasks")
-    relaxng = etree.RelaxNG(file=relaxng_doc)
+        with open(resc / "schema_with_metatasks.rng", "r", encoding="utf-8") as f:
+            schema = etree.RelaxNG(etree.parse(f))
+
+    valid_xml = support.fixture_path("hello_workflow.xml")
+    tree = etree.parse(valid_xml)
+    assert schema.validate(tree)
+
+    invalid_xml = support.fixture_path("rocoto_invalid.xml")
+    tree = etree.parse(invalid_xml)
+    assert not schema.validate(tree)

--- a/src/uwtools/tests/test_rocoto.py
+++ b/src/uwtools/tests/test_rocoto.py
@@ -66,4 +66,4 @@ def test_rocoto_xml_is_valid():
 
     invalid_xml = support.fixture_path("rocoto_invalid.xml")
     tree = etree.parse(invalid_xml)
-    assert not schema.validate(tree)
+    assert schema.validate(tree) is False

--- a/src/uwtools/tests/test_rocoto.py
+++ b/src/uwtools/tests/test_rocoto.py
@@ -3,6 +3,7 @@
 Tests for uwtools.rocoto module.
 """
 from importlib import resources
+from lxml import etree
 
 import yaml
 
@@ -52,3 +53,9 @@ def test_write_rocoto_xml(tmp_path):
 
     expected = support.fixture_path("hello_workflow.xml")
     support.compare_files(expected, output)
+
+def test_rocoto_xml_is_valid():
+    input_xml = support.fixture_path("hello_workflow.xml")
+    tree = etree.parse(input_xml)
+    root = etree.tostring(tree.getroot())
+    breakpoint()

--- a/src/uwtools/tests/test_rocoto.py
+++ b/src/uwtools/tests/test_rocoto.py
@@ -58,4 +58,3 @@ def test_rocoto_xml_is_valid():
     input_xml = support.fixture_path("hello_workflow.xml")
     tree = etree.parse(input_xml)
     root = etree.tostring(tree.getroot())
-    breakpoint()

--- a/src/uwtools/tests/test_rocoto.py
+++ b/src/uwtools/tests/test_rocoto.py
@@ -5,6 +5,7 @@ Tests for uwtools.rocoto module.
 from importlib import resources
 
 import yaml
+import pytest
 from lxml import etree
 
 from uwtools import rocoto
@@ -55,15 +56,13 @@ def test_write_rocoto_xml(tmp_path):
     support.compare_files(expected, output)
 
 
-def test_rocoto_xml_is_valid():
+@pytest.mark.parametrize("vals", [("hello_workflow.xml", True), ("rocoto_invalid.xml", False)])
+def test_rocoto_xml_is_valid(vals):
+    fn, validity = vals
     with resources.as_file(resources.files("uwtools.resources")) as resc:
         with open(resc / "schema_with_metatasks.rng", "r", encoding="utf-8") as f:
             schema = etree.RelaxNG(etree.parse(f))
 
-    valid_xml = support.fixture_path("hello_workflow.xml")
-    tree = etree.parse(valid_xml)
-    assert schema.validate(tree)
-
-    invalid_xml = support.fixture_path("rocoto_invalid.xml")
-    tree = etree.parse(invalid_xml)
-    assert schema.validate(tree) is False
+    xml = support.fixture_path(fn)
+    tree = etree.parse(xml)
+    assert schema.validate(tree) is validity

--- a/src/uwtools/tests/test_rocoto.py
+++ b/src/uwtools/tests/test_rocoto.py
@@ -3,9 +3,9 @@
 Tests for uwtools.rocoto module.
 """
 from importlib import resources
-from lxml import etree
 
 import yaml
+from lxml import etree
 
 from uwtools import rocoto
 from uwtools.tests import support
@@ -54,7 +54,13 @@ def test_write_rocoto_xml(tmp_path):
     expected = support.fixture_path("hello_workflow.xml")
     support.compare_files(expected, output)
 
+
 def test_rocoto_xml_is_valid():
     input_xml = support.fixture_path("hello_workflow.xml")
     tree = etree.parse(input_xml)
     root = etree.tostring(tree.getroot())
+
+    breakpoint()
+    with resources.as_file(resources.files("uwtools.resources")) as resc:
+        relaxng_doc = str(resc / "schema_with_metatasks")
+    relaxng = etree.RelaxNG(file=relaxng_doc)


### PR DESCRIPTION
<!--
- - -  I N S T R U C T I O N S  --  P L E A S E  R E A D  - - -
Please remove boiler plate instructions when filling out this template.
Please remove unwanted/unrelated/irrelevant information such as comments provided as a reference in this template.
Use proper formatting to separate code snippets from text description e.g. use ```code block``` or `in-line code`.
Please copy any output files into a Github gist (for e.g.) and link to the gist, rather than relying on paths on platforms that might change or disappear.

Before opening a PR, please note these guidelines:

- Each PR should only address ONE topic and have an associated GitHub issue
- No hardcoded or paths to personal directories should be present
- No temporary or backup files should be committed
- Any code that was disabled by being commented out should be removed
- Please provide a on-line, but descriptive title to the PR e.g. Adds XYZ functionality or Fixes ABC bugs, etc.  DO NOT use branch names as titles.
-->

**Description**

<!-- Please include relevant motivation and context. -->
<!-- Please include a summary of the change and which issue is fixed. -->
<!-- List any dependencies that are required for this change. -->

<!-- Please provide reference to the issue this pull request is addressing. -->
<!-- For e.g. Fixes #IssueNumber -->
- One of the most difficult/complex workflow end-to-end tests to get "right" has been the MET_ensemble_verification. It creates multiple nested metatasks, and uses many of the supported dependency flags. It most fully utilizes the functionalities we need to support for Rocoto XML generation.
- Perhaps we can ensure that we match the SRW expected file in one of our tests. We do NOT want to be running this WE2E test as part of our suite.
- Re-scoping this work for now to have a test read in a Rocoto XML with lxml and tell us if it is valid or not. We will have both a valid and an invalid one.
- The only thing needed to satisfy that goal would be a unit test that does that comparison and returns a true/false.

**Type of change**

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**
<!-- Please describe the tests that you ran to verify your changes. -->
<!-- Provide instructions so we can reproduce. -->
<!-- Please also list any relevant details for your test configuration -->

<!-- Use the following as a guide to list your tests and delete options that are not relevant. Expand as necessary. -->
<!--
- [ ] pytests in GitHub actions.
- [ ] Tests on XYZ OS/HPC/CSP
-->
Passes all development-shell `make format && make test` code-quality checks, including (updated) unit tests.

**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes need updates to the documentation.  I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [x] Any dependent changes have been merged and published

<!-- 
 If there is a co-author attribution:

Update the final commit message (when squashing and merging) to include  `Co-authored-by: name <name@example.com>` (e.g. `Co-authored-by: Jane Doe <jane_doe@example.com>`).  Each co-author must have their own line, and the email address used must be the email address connected with their GitHub account.
-->
