### PR TITLE
UW-362: rename uwtools.config.str_to_type() & consider mandating YAML values

### DIFF
--- a/src/uwtools/config/core.py
+++ b/src/uwtools/config/core.py
@@ -267,7 +267,7 @@ class Config(ABC, UserDict):
 
                     # Put the full template line back together as it was, filled or not, and make a
                     # guess on its intended type.
-                    ref_dict[key] = self.str_to_type("".join(data))
+                    ref_dict[key] = self.reify_str("".join(data))
 
     def dereference_all(self) -> None:
         """
@@ -332,31 +332,14 @@ class Config(ABC, UserDict):
                     self.update_values(self._load_paths(filepaths))
                     del ref_dict[key]
 
-    def str_to_type(self, s: str) -> Union[bool, float, int, str]:
+    def reify_str(self, s: str) -> Union[bool, float, int, str]:
         """
-        Reify a string to a Python object, if possible.
-
-        Try to convert Boolean-ish values to bool objects, int-ish values to ints objects, and
-        float-ish values to float objects. Return the original string if none of these apply.
+        Reify a string to a Python object, using YAML. Jinja2 templates will be passed as-is.
 
         :param s: The string to reify.
         """
         s = s.strip("\"'")
-        if s.lower() in ["true", "yes", "yeah"]:
-            return True
-        if s.lower() in ["false", "no", "nope"]:
-            return False
-        # int
-        try:
-            return int(s)
-        except ValueError:
-            pass
-        # float
-        try:
-            return float(s)
-        except ValueError:
-            pass
-        return s
+        return s if "{{" in s or "{%" in s else yaml.safe_load(s)
 
     def update_values(self, src: Union[dict, Config], dst: Optional[Config] = None):
         """

--- a/src/uwtools/config/core.py
+++ b/src/uwtools/config/core.py
@@ -340,7 +340,7 @@ class Config(ABC, UserDict):
         """
         try:
             r = yaml.safe_load(s)
-        except (yaml.YAMLError, AttributeError):
+        except yaml.YAMLError:
             return s
         return s if type(r) in [dict, list] else r
 

--- a/src/uwtools/config/core.py
+++ b/src/uwtools/config/core.py
@@ -267,7 +267,7 @@ class Config(ABC, UserDict):
 
                     # Put the full template line back together as it was, filled or not, and make a
                     # guess on its intended type.
-                    ref_dict[key] = self.reify_str("".join(data))
+                    ref_dict[key] = self.reify_scalar_str("".join(data))
 
     def dereference_all(self) -> None:
         """
@@ -332,14 +332,17 @@ class Config(ABC, UserDict):
                     self.update_values(self._load_paths(filepaths))
                     del ref_dict[key]
 
-    def reify_str(self, s: str) -> Union[bool, float, int, str]:
+    def reify_scalar_str(self, s: str) -> Union[bool, float, int, str]:
         """
         Reify a string to a Python object, using YAML. Jinja2 templates will be passed as-is.
 
         :param s: The string to reify.
         """
-        s = s.strip("\"'")
-        return s if "{{" in s or "{%" in s else yaml.safe_load(s)
+        try:
+            r = yaml.safe_load(s)
+        except (yaml.YAMLError, AttributeError):
+            return s
+        return s if type(r) in [dict, list] else r
 
     def update_values(self, src: Union[dict, Config], dst: Optional[Config] = None):
         """

--- a/src/uwtools/tests/config/test_core.py
+++ b/src/uwtools/tests/config/test_core.py
@@ -161,7 +161,7 @@ def test_dereference():
         assert cfg["grid_stats"]["total_ens_points"] == 19200000
 
         # Check that statements expand:
-        assert cfg["fcst"]["output_hours"] == "0 3 6 9 "
+        assert cfg["fcst"]["output_hours"] == "0 3 6 9"
 
         # Check that order isn't a problem:
         assert cfg["grid_stats"]["points_per_level"] == 10000

--- a/src/uwtools/tests/config/test_core.py
+++ b/src/uwtools/tests/config/test_core.py
@@ -862,14 +862,14 @@ def test_Config_characterize_values(nml_cfgobj):
     assert template == ["    p3: {{ n }}"]
 
 
-def test_Config_str_to_type(nml_cfgobj):
-    for x in ["true", "yes", "yeah"]:
-        assert nml_cfgobj.str_to_type(x) is True
-    for x in ["false", "no", "nope"]:
-        assert nml_cfgobj.str_to_type(x) is False
-    assert nml_cfgobj.str_to_type("88") == 88
-    assert nml_cfgobj.str_to_type("3.14") == 3.14
-    assert nml_cfgobj.str_to_type("NA") == "NA"  # no conversion
+def test_Config_reify_str(f90_cfgobj):
+    for x in ["true", "yes", "TRUE"]:
+        assert f90_cfgobj.reify_str(x) is True
+    for x in ["false", "no", "FALSE"]:
+        assert f90_cfgobj.reify_str(x) is False
+    assert f90_cfgobj.reify_str("88") == 88
+    assert f90_cfgobj.reify_str("3.14") == 3.14
+    assert f90_cfgobj.reify_str("maybe") == "maybe"  # no conversion
 
 
 def test_Config_dereference_unexpected_error(nml_cfgobj):

--- a/src/uwtools/tests/config/test_core.py
+++ b/src/uwtools/tests/config/test_core.py
@@ -862,14 +862,16 @@ def test_Config_characterize_values(nml_cfgobj):
     assert template == ["    p3: {{ n }}"]
 
 
-def test_Config_reify_str(nml_cfgobj):
+def test_Config_reify_scalar_str(nml_cfgobj):
     for x in ["true", "yes", "TRUE"]:
-        assert nml_cfgobj.reify_str(x) is True
+        assert nml_cfgobj.reify_scalar_str(x) is True
     for x in ["false", "no", "FALSE"]:
-        assert nml_cfgobj.reify_str(x) is False
-    assert nml_cfgobj.reify_str("88") == 88
-    assert nml_cfgobj.reify_str("3.14") == 3.14
-    assert nml_cfgobj.reify_str("maybe") == "maybe"  # no conversion
+        assert nml_cfgobj.reify_scalar_str(x) is False
+    assert nml_cfgobj.reify_scalar_str("88") == 88
+    assert nml_cfgobj.reify_scalar_str("3.14") == 3.14
+    assert nml_cfgobj.reify_scalar_str("NA") == "NA"  # no conversion
+    assert nml_cfgobj.reify_scalar_str("cycle: '06'") == "cycle: '06'"
+    assert nml_cfgobj.reify_scalar_str([1, 2, 3]) == [1, 2, 3]
 
 
 def test_Config_dereference_unexpected_error(nml_cfgobj):

--- a/src/uwtools/tests/config/test_core.py
+++ b/src/uwtools/tests/config/test_core.py
@@ -862,14 +862,14 @@ def test_Config_characterize_values(nml_cfgobj):
     assert template == ["    p3: {{ n }}"]
 
 
-def test_Config_reify_str(f90_cfgobj):
+def test_Config_reify_str(nml_cfgobj):
     for x in ["true", "yes", "TRUE"]:
-        assert f90_cfgobj.reify_str(x) is True
+        assert nml_cfgobj.reify_str(x) is True
     for x in ["false", "no", "FALSE"]:
-        assert f90_cfgobj.reify_str(x) is False
-    assert f90_cfgobj.reify_str("88") == 88
-    assert f90_cfgobj.reify_str("3.14") == 3.14
-    assert f90_cfgobj.reify_str("maybe") == "maybe"  # no conversion
+        assert nml_cfgobj.reify_str(x) is False
+    assert nml_cfgobj.reify_str("88") == 88
+    assert nml_cfgobj.reify_str("3.14") == 3.14
+    assert nml_cfgobj.reify_str("maybe") == "maybe"  # no conversion
 
 
 def test_Config_dereference_unexpected_error(nml_cfgobj):

--- a/src/uwtools/tests/config/test_core.py
+++ b/src/uwtools/tests/config/test_core.py
@@ -868,10 +868,13 @@ def test_Config_reify_scalar_str(nml_cfgobj):
     for x in ["false", "no", "FALSE"]:
         assert nml_cfgobj.reify_scalar_str(x) is False
     assert nml_cfgobj.reify_scalar_str("88") == 88
+    assert nml_cfgobj.reify_scalar_str("'88'") == "88"  # quoted int not converted
     assert nml_cfgobj.reify_scalar_str("3.14") == 3.14
     assert nml_cfgobj.reify_scalar_str("NA") == "NA"  # no conversion
-    assert nml_cfgobj.reify_scalar_str("cycle: '06'") == "cycle: '06'"
-    assert nml_cfgobj.reify_scalar_str([1, 2, 3]) == [1, 2, 3]
+    assert nml_cfgobj.reify_scalar_str("@[foo]") == "@[foo]"  # no conversion for YAML exceptions
+    with raises(AttributeError) as e:
+        nml_cfgobj.reify_scalar_str([1, 2, 3])
+    assert "'list' object has no attribute 'read'" in str(e.value)  # Exception on unintended list
 
 
 def test_Config_dereference_unexpected_error(nml_cfgobj):


### PR DESCRIPTION
**Description**
Acceptance Criteria:
Function has an accurate name
String values are parsed with the YAML library and acceptable inputs are synonymous with acceptable YAML values

Jira issue UW-362
Fixes issue #286 

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**


- [x] pytests in GitHub actions.
- [x] Tests on Ubuntu OS

**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes need updates to the documentation.  I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [x] Any dependent changes have been merged and published