### PR TITLE
flexible-arg-post-processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,4 +140,3 @@ Documentation is automatically generated through [Read the Docs](https://readthe
 [Developer Status](https://github.com/orgs/ufs-community/projects/1)
 
 [UW Tools Github Pages Site](https://ufs-community.github.io/workflow-tools/)
-

--- a/src/uwtools/cli.py
+++ b/src/uwtools/cli.py
@@ -83,18 +83,18 @@ def _add_subparser_config_compare(subparsers: Subparsers) -> SubmodeChecks:
     """
     parser = _add_subparser(subparsers, STR.compare, "Compare configs")
     required = parser.add_argument_group(TITLE_REQ_ARG)
-    _add_arg_file_path(required, switch=_arg2sw(STR.file1path), helpmsg="Path to file 1")
-    _add_arg_file_path(required, switch=_arg2sw(STR.file2path), helpmsg="Path to file 2")
+    _add_arg_file_path(required, switch=_switch(STR.file1path), helpmsg="Path to file 1")
+    _add_arg_file_path(required, switch=_switch(STR.file2path), helpmsg="Path to file 2")
     optional = _basic_setup(parser)
     _add_arg_file_format(
         optional,
-        switch=_arg2sw(STR.file1fmt),
+        switch=_switch(STR.file1fmt),
         helpmsg="Format of file 1",
         choices=FORMATS,
     )
     _add_arg_file_format(
         optional,
-        switch=_arg2sw(STR.file2fmt),
+        switch=_switch(STR.file2fmt),
         helpmsg="Format of file 2",
         choices=FORMATS,
     )
@@ -368,7 +368,7 @@ def _dispatch_template_render(args: Namespace) -> bool:
 
 def _add_arg_config_file(group: Group) -> None:
     group.add_argument(
-        _arg2sw(STR.cfgfile),
+        _switch(STR.cfgfile),
         "-c",
         help="Path to config file",
         metavar="PATH",
@@ -379,7 +379,7 @@ def _add_arg_config_file(group: Group) -> None:
 
 def _add_arg_dry_run(group: Group) -> None:
     group.add_argument(
-        _arg2sw(STR.dryrun),
+        _switch(STR.dryrun),
         action="store_true",
         help="Only log info, making no changes",
     )
@@ -409,7 +409,7 @@ def _add_arg_file_path(group: Group, switch: str, helpmsg: str, required: bool =
 
 def _add_arg_input_file(group: Group, required: bool = False) -> None:
     group.add_argument(
-        _arg2sw(STR.infile),
+        _switch(STR.infile),
         "-i",
         help="Path to input file (defaults to stdin)",
         metavar="PATH",
@@ -420,7 +420,7 @@ def _add_arg_input_file(group: Group, required: bool = False) -> None:
 
 def _add_arg_input_format(group: Group, choices: List[str], required: bool = False) -> None:
     group.add_argument(
-        _arg2sw(STR.infmt),
+        _switch(STR.infmt),
         choices=choices,
         help="Input format",
         required=required,
@@ -439,7 +439,7 @@ def _add_arg_key_eq_val_pairs(group: Group) -> None:
 
 def _add_arg_model(group: Group, choices: List[str]) -> None:
     group.add_argument(
-        _arg2sw(STR.model),
+        _switch(STR.model),
         choices=choices,
         help="Model name",
         required=True,
@@ -449,7 +449,7 @@ def _add_arg_model(group: Group, choices: List[str]) -> None:
 
 def _add_arg_output_file(group: Group, required: bool = False) -> None:
     group.add_argument(
-        _arg2sw(STR.outfile),
+        _switch(STR.outfile),
         "-o",
         help="Path to output file (defaults to stdout)",
         metavar="PATH",
@@ -460,7 +460,7 @@ def _add_arg_output_file(group: Group, required: bool = False) -> None:
 
 def _add_arg_output_format(group: Group, choices: List[str], required: bool = False) -> None:
     group.add_argument(
-        _arg2sw(STR.outfmt),
+        _switch(STR.outfmt),
         choices=choices,
         help="Output format",
         required=required,
@@ -470,7 +470,7 @@ def _add_arg_output_format(group: Group, choices: List[str], required: bool = Fa
 
 def _add_arg_quiet(group: Group) -> None:
     group.add_argument(
-        _arg2sw(STR.quiet),
+        _switch(STR.quiet),
         "-q",
         action="store_true",
         help="Print no logging messages",
@@ -479,7 +479,7 @@ def _add_arg_quiet(group: Group) -> None:
 
 def _add_arg_schema_file(group: Group) -> None:
     group.add_argument(
-        _arg2sw(STR.schemafile),
+        _switch(STR.schemafile),
         help="Path to schema file to use for validation",
         metavar="PATH",
         required=True,
@@ -489,7 +489,7 @@ def _add_arg_schema_file(group: Group) -> None:
 
 def _add_arg_values_file(group: Group, required: bool = False) -> None:
     group.add_argument(
-        _arg2sw(STR.valsfile),
+        _switch(STR.valsfile),
         help="Path to file providing override or interpolation values",
         metavar="PATH",
         required=required,
@@ -499,7 +499,7 @@ def _add_arg_values_file(group: Group, required: bool = False) -> None:
 
 def _add_arg_values_format(group: Group, choices: List[str]) -> None:
     group.add_argument(
-        _arg2sw(STR.valsfmt),
+        _switch(STR.valsfmt),
         choices=choices,
         help="Values format",
         required=False,
@@ -509,7 +509,7 @@ def _add_arg_values_format(group: Group, choices: List[str]) -> None:
 
 def _add_arg_values_needed(group: Group) -> None:
     group.add_argument(
-        _arg2sw(STR.valsneeded),
+        _switch(STR.valsneeded),
         action="store_true",
         help="Print report of values needed to render template",
     )
@@ -517,7 +517,7 @@ def _add_arg_values_needed(group: Group) -> None:
 
 def _add_arg_verbose(group: Group) -> None:
     group.add_argument(
-        _arg2sw(STR.verbose),
+        _switch(STR.verbose),
         "-v",
         action="store_true",
         help="Print all logging messages",
@@ -578,16 +578,6 @@ def _add_subparsers(parser: Parser, dest: str) -> Subparsers:
     )
 
 
-def _arg2sw(arg: str) -> str:
-    """
-    Convert argument name to long-form switch.
-
-    :param arg: Internal name of parsed argument.
-    :return: The long-form switch.
-    """
-    return "--%s" % arg.replace("_", "-")
-
-
 def _basic_setup(parser: Parser) -> Group:
     """
     Create optional-arguments group and add help switch.
@@ -595,7 +585,7 @@ def _basic_setup(parser: Parser) -> Group:
     :param parser: The parser to add the optional group to.
     """
     optional = parser.add_argument_group("Optional arguments")
-    optional.add_argument("-h", _arg2sw(STR.help), action=STR.help, help="Show help and exit")
+    optional.add_argument("-h", _switch(STR.help), action=STR.help, help="Show help and exit")
     return optional
 
 
@@ -603,7 +593,7 @@ def _check_file_vs_format(file_arg: str, format_arg: str, args: Namespace) -> Na
     a = vars(args)
     if a[format_arg] is None:
         if a[file_arg] is None:
-            _abort("Specify %s when %s is not specified" % (_arg2sw(format_arg), _arg2sw(file_arg)))
+            _abort("Specify %s when %s is not specified" % (_switch(format_arg), _switch(file_arg)))
         a[format_arg] = get_file_type(a[file_arg])
     return args
 
@@ -611,7 +601,7 @@ def _check_file_vs_format(file_arg: str, format_arg: str, args: Namespace) -> Na
 def _check_quiet_vs_verbose(args) -> Namespace:
     a = vars(args)
     if a.get(STR.quiet) and a.get(STR.verbose):
-        _abort("Specify at most one of %s, %s" % (_arg2sw(STR.quiet), _arg2sw(STR.verbose)))
+        _abort("Specify at most one of %s, %s" % (_switch(STR.quiet), _switch(STR.verbose)))
     return args
 
 
@@ -662,6 +652,16 @@ def _parse_args(raw_args: List[str]) -> Tuple[Namespace, Checks]:
         STR.template: _add_subparser_template(subparsers),
     }
     return parser.parse_args(raw_args), checks
+
+
+def _switch(arg: str) -> str:
+    """
+    Convert argument name to long-form switch.
+
+    :param arg: Internal name of parsed argument.
+    :return: The long-form switch.
+    """
+    return "--%s" % arg.replace("_", "-")
 
 
 @dataclass(frozen=True)

--- a/src/uwtools/cli.py
+++ b/src/uwtools/cli.py
@@ -44,7 +44,7 @@ def main() -> None:
     try:
         args, checks = _parse_args(sys.argv[1:])
         for check in checks[args.mode][args.submode]:
-            check()
+            check(args)
         setup_logging(quiet=args.quiet, verbose=args.verbose)
         logging.debug("Command: %s %s", Path(sys.argv[0]).name, " ".join(sys.argv[1:]))
         modes = {

--- a/src/uwtools/cli.py
+++ b/src/uwtools/cli.py
@@ -100,7 +100,8 @@ def _add_subparser_config_compare(subparsers: Subparsers) -> SubmodeChecks:
         helpmsg="Format of file 2",
         choices=FORMATS,
     )
-    return _add_args_quiet_and_verbose(optional) + [
+    checks = _add_args_quiet_and_verbose(optional)
+    return checks + [
         partial(_check_file_vs_format, STR.file1path, STR.file1fmt),
         partial(_check_file_vs_format, STR.file2path, STR.file2fmt),
     ]
@@ -123,7 +124,8 @@ def _add_subparser_config_realize(subparsers: Subparsers) -> SubmodeChecks:
     _add_arg_values_format(optional, choices=FORMATS)
     _add_arg_values_needed(optional)
     _add_arg_dry_run(optional)
-    return _add_args_quiet_and_verbose(optional) + [
+    checks = _add_args_quiet_and_verbose(optional)
+    return checks + [
         partial(_check_file_vs_format, STR.infile, STR.infmt),
         partial(_check_file_vs_format, STR.outfile, STR.outfmt),
         partial(_check_file_vs_format, STR.valsfile, STR.valsfmt),
@@ -143,7 +145,8 @@ def _add_subparser_config_translate(subparsers: Subparsers) -> SubmodeChecks:
     _add_arg_output_file(optional)
     _add_arg_output_format(optional, choices=[FORMAT.jinja2])
     _add_arg_dry_run(optional)
-    return _add_args_quiet_and_verbose(optional) + [
+    checks = _add_args_quiet_and_verbose(optional)
+    return checks + [
         partial(_check_file_vs_format, STR.infile, STR.infmt),
         partial(_check_file_vs_format, STR.outfile, STR.outfmt),
     ]
@@ -161,7 +164,8 @@ def _add_subparser_config_validate(subparsers: Subparsers) -> SubmodeChecks:
     optional = _basic_setup(parser)
     _add_arg_input_file(optional)
     _add_arg_input_format(optional, choices=[FORMAT.yaml])
-    return _add_args_quiet_and_verbose(optional) + [
+    checks = _add_args_quiet_and_verbose(optional)
+    return checks + [
         partial(_check_file_vs_format, STR.infile, STR.infmt),
     ]
 
@@ -273,7 +277,8 @@ def _add_subparser_forecast_run(subparsers: Subparsers) -> SubmodeChecks:
     _add_arg_model(required, choices=["FV3"])
     optional = _basic_setup(parser)
     _add_arg_dry_run(optional)
-    return _add_args_quiet_and_verbose(optional)
+    checks = _add_args_quiet_and_verbose(optional)
+    return checks
 
 
 def _dispatch_forecast(args: Namespace) -> bool:
@@ -328,7 +333,8 @@ def _add_subparser_template_render(subparsers: Subparsers) -> SubmodeChecks:
     _add_arg_values_needed(optional)
     _add_arg_dry_run(optional)
     _add_arg_key_eq_val_pairs(optional)
-    return _add_args_quiet_and_verbose(optional)
+    checks = _add_args_quiet_and_verbose(optional)
+    return checks
 
 
 def _dispatch_template(args: Namespace) -> bool:

--- a/src/uwtools/cli.py
+++ b/src/uwtools/cli.py
@@ -322,13 +322,6 @@ def _add_subparser_template_render(subparsers: Subparsers) -> SubmodeChecks:
 
     :param subparsers: Parent parser's subparsers, to add this subparser to.
     """
-    # In this submode, input/output files are optional (stdin and stdout are used by default),
-    # and their formats are irrelevant because they're treated as generic text. A values file
-    # is also optional, as values used to render the template will be taken from the environment
-    # or from key=value command-line pairs by default. However, if a values file IS specified,
-    # its format must either be explicitly specified, or deduced from its extension, so a check
-    # is provided for this case.
-
     parser = _add_subparser(subparsers, STR.render, "Render a template")
     optional = _basic_setup(parser)
     _add_arg_input_file(optional)
@@ -623,6 +616,10 @@ def _check_quiet_vs_verbose(args) -> Namespace:
 
 
 def _check_template_render_vals_args(args: Namespace) -> Namespace:
+    # In "template render" mode, a values file is optional, as values used to render the template
+    # will be taken from the environment or from key=value command-line pairs by default. But if a
+    # values file IS specified, its format must either be explicitly specified, or deduced from its
+    # extension.
     a = vars(args)
     if a.get(STR.valsfile) is not None:
         if a.get(STR.valsfmt) is None:

--- a/src/uwtools/cli.py
+++ b/src/uwtools/cli.py
@@ -41,17 +41,17 @@ def main() -> None:
     # handler. Shield command-line users from raised exceptions by aborting gracefully.
 
     setup_logging(quiet=True)
+    modes = {
+        STR.config: _dispatch_config,
+        STR.forecast: _dispatch_forecast,
+        STR.template: _dispatch_template,
+    }
     try:
         args, checks = _parse_args(sys.argv[1:])
         for check in checks[args.mode][args.submode]:
             check(args)
         setup_logging(quiet=args.quiet, verbose=args.verbose)
         logging.debug("Command: %s %s", Path(sys.argv[0]).name, " ".join(sys.argv[1:]))
-        modes = {
-            STR.config: _dispatch_config,
-            STR.forecast: _dispatch_forecast,
-            STR.template: _dispatch_template,
-        }
         sys.exit(0 if modes[args.mode](args) else 1)
     except Exception as e:  # pylint: disable=broad-exception-caught
         _abort(str(e))

--- a/src/uwtools/cli.py
+++ b/src/uwtools/cli.py
@@ -437,7 +437,7 @@ def _add_arg_input_format(group: Group, choices: List[str], required: bool = Fal
 
 def _add_arg_key_eq_val_pairs(group: Group) -> None:
     group.add_argument(
-        "key_eq_val_pairs",
+        STR.keyvalpairs,
         help="A key=value pair to override/supplement config",
         metavar="KEY=VALUE",
         nargs="*",

--- a/src/uwtools/cli.py
+++ b/src/uwtools/cli.py
@@ -40,17 +40,17 @@ def main() -> None:
     # handler. Shield command-line users from raised exceptions by aborting gracefully.
 
     setup_logging(quiet=True)
-    modes = {
-        "config": _dispatch_config,
-        "forecast": _dispatch_forecast,
-        "template": _dispatch_template,
-    }
     try:
         args, checks = _parse_args(sys.argv[1:])
         for check in checks[args.mode][args.submode]:
             check()
         setup_logging(quiet=args.quiet, verbose=args.verbose)
         logging.debug("Command: %s %s", Path(sys.argv[0]).name, " ".join(sys.argv[1:]))
+        modes = {
+            "config": _dispatch_config,
+            "forecast": _dispatch_forecast,
+            "template": _dispatch_template,
+        }
         sys.exit(0 if modes[args.mode](args) else 1)
     except Exception as e:  # pylint: disable=broad-exception-caught
         _abort(str(e))

--- a/src/uwtools/cli.py
+++ b/src/uwtools/cli.py
@@ -685,6 +685,7 @@ class _STR:
     help: str = "help"
     infile: str = "input_file"
     infmt: str = "input_format"
+    keyvalpairs: str = "key_eq_val_pairs"
     mode: str = "mode"
     model: str = "model"
     outfile: str = "output_file"

--- a/src/uwtools/cli.py
+++ b/src/uwtools/cli.py
@@ -581,7 +581,7 @@ def _basic_setup(parser: Parser) -> Group:
     :param parser: The parser to add the optional group to.
     """
     optional = parser.add_argument_group("Optional arguments")
-    optional.add_argument("-h", "--help", action="help", help="Show help and exit")
+    optional.add_argument("-h", _arg2sw(STR.help), action="help", help="Show help and exit")
     return optional
 
 

--- a/src/uwtools/cli.py
+++ b/src/uwtools/cli.py
@@ -24,7 +24,7 @@ from uwtools.utils.file import FORMAT, get_file_type
 FORMATS = [FORMAT.ini, FORMAT.nml, FORMAT.yaml]
 TITLE_REQ_ARG = "Required arguments"
 
-SubmodeChecks = List[Callable]
+SubmodeChecks = List[Callable[[Namespace], Namespace]]
 ModeChecks = Dict[str, SubmodeChecks]
 Checks = Dict[str, ModeChecks]
 

--- a/src/uwtools/config/core.py
+++ b/src/uwtools/config/core.py
@@ -675,7 +675,6 @@ def compare_configs(
     :param config_b_format: Format of second config file.
     :return: False if config files had differences, otherwise True.
     """
-
     cfg_a = format_to_config(config_a_format)(config_a_path)
     cfg_b = format_to_config(config_b_format)(config_b_path)
     logging.info("- %s", config_a_path)

--- a/src/uwtools/config/core.py
+++ b/src/uwtools/config/core.py
@@ -675,6 +675,7 @@ def compare_configs(
     :param config_b_format: Format of second config file.
     :return: False if config files had differences, otherwise True.
     """
+
     cfg_a = format_to_config(config_a_format)(config_a_path)
     cfg_b = format_to_config(config_b_format)(config_b_path)
     logging.info("- %s", config_a_path)

--- a/src/uwtools/logging.py
+++ b/src/uwtools/logging.py
@@ -23,6 +23,9 @@ def setup_logging(quiet: bool = False, verbose: bool = False) -> None:
     :param quiet: Supress all logging output.
     :param verbose: Log all messages.
     """
+    logger = logging.getLogger()
+    for handler in logger.handlers:
+        logger.removeHandler(handler)
     if quiet and verbose:
         print("Specify at most one of 'quiet' and 'verbose'", file=sys.stderr)
         sys.exit(1)

--- a/src/uwtools/tests/config/test_atparse_to_jinja2.py
+++ b/src/uwtools/tests/config/test_atparse_to_jinja2.py
@@ -3,6 +3,7 @@
 Tests for uwtools.utils.atparse_to_jinja2 module.
 """
 
+import logging
 import sys
 from io import StringIO
 from unittest.mock import patch
@@ -47,6 +48,7 @@ def test_convert_input_file_to_output_file(atparsefile, capsys, jinja2txt, tmp_p
 
 
 def test_convert_input_file_to_logging(atparsefile, caplog, capsys, jinja2txt, tmp_path):
+    logging.getLogger().setLevel(logging.INFO)
     outfile = tmp_path / "outfile"
     atparse_to_jinja2.convert(input_file=atparsefile, dry_run=True)
     streams = capsys.readouterr()
@@ -74,6 +76,7 @@ def test_convert_stdin_to_file(atparselines, capsys, jinja2txt, tmp_path):
 
 
 def test_convert_stdin_to_logging(atparselines, caplog, jinja2txt, tmp_path):
+    logging.getLogger().setLevel(logging.INFO)
     outfile = tmp_path / "outfile"
     with patch.object(sys, "stdin", new=StringIO("\n".join(atparselines))):
         atparse_to_jinja2.convert(output_file=outfile, dry_run=True)

--- a/src/uwtools/tests/config/test_core.py
+++ b/src/uwtools/tests/config/test_core.py
@@ -55,6 +55,7 @@ def test_compare_config(caplog, fmt, salad_base):
 
 
 def test_compare_configs_good(compare_configs_assets, caplog):
+    logging.getLogger().setLevel(logging.INFO)
     _, a, b = compare_configs_assets
     assert core.compare_configs(
         config_a_path=a, config_a_format=FORMAT.yaml, config_b_path=b, config_b_format=FORMAT.yaml
@@ -63,6 +64,7 @@ def test_compare_configs_good(compare_configs_assets, caplog):
 
 
 def test_compare_configs_changed_value(compare_configs_assets, caplog):
+    logging.getLogger().setLevel(logging.INFO)
     d, a, b = compare_configs_assets
     d["baz"]["qux"] = 11
     with writable(b) as f:
@@ -74,6 +76,7 @@ def test_compare_configs_changed_value(compare_configs_assets, caplog):
 
 
 def test_compare_configs_missing_key(compare_configs_assets, caplog):
+    logging.getLogger().setLevel(logging.INFO)
     d, a, b = compare_configs_assets
     del d["baz"]
     with writable(b) as f:
@@ -612,6 +615,7 @@ def test__realize_config_update(realize_config_testobj, tmp_path):
 
 
 def test__realize_config_values_needed(caplog, tmp_path):
+    logging.getLogger().setLevel(logging.INFO)
     path = tmp_path / "a.yaml"
     with writable(path) as f:
         yaml.dump({1: "complete", 2: "{{ jinja2 }}", 3: ""}, f)
@@ -906,7 +910,7 @@ def test_YAMLConfig__load_paths_failure_stdin_plus_relpath(caplog):
     # provide YAML with an include directive specifying a relative path. Since a relative path
     # is meaningless relative to stdin, assert that an appropriate error is logged and exception
     # raised.
-
+    logging.getLogger().setLevel(logging.INFO)
     relpath = "../bar/baz.yaml"
     with patch.object(core.sys, "stdin", new=StringIO(f"foo: {core.INCLUDE_TAG} [{relpath}]")):
         with raises(UWConfigError) as e:

--- a/src/uwtools/tests/config/test_templater.py
+++ b/src/uwtools/tests/config/test_templater.py
@@ -61,6 +61,7 @@ def test_render_dry_run(caplog, values_file, template):
 
 def test_render_values_missing(caplog, values_file, template):
     # Read in the config, remove the "roses" key, then re-write it.
+    logging.getLogger().setLevel(logging.INFO)
     with open(values_file, "r", encoding="utf-8") as f:
         cfgobj = yaml.safe_load(f.read())
     del cfgobj["roses"]

--- a/src/uwtools/tests/config/test_validator.py
+++ b/src/uwtools/tests/config/test_validator.py
@@ -4,6 +4,7 @@ Tests for uwtools.config.validator module.
 """
 
 import json
+import logging
 from pathlib import Path
 from typing import Any, Dict
 
@@ -74,6 +75,7 @@ def write_as_json(data: Dict[str, Any], path: Path) -> Path:
 
 def test_validate_yaml_fail_bad_dir_top(caplog, config, config_file, schema, schema_file, tmp_path):
     # Specify a non-existent directory for the topmost directory value.
+    logging.getLogger().setLevel(logging.INFO)
     d = str(tmp_path / "no-such-dir")
     config["dir"] = d
     write_as_json(config, config_file)
@@ -86,6 +88,7 @@ def test_validate_yaml_fail_bad_dir_nested(
     caplog, config, config_file, schema, schema_file, tmp_path
 ):
     # Specify a non-existent directory for the nested directory value.
+    logging.getLogger().setLevel(logging.INFO)
     d = str(tmp_path / "no-such-dir")
     config["sub"]["dir"] = d
     write_as_json(config, config_file)
@@ -96,6 +99,7 @@ def test_validate_yaml_fail_bad_dir_nested(
 
 def test_validate_yaml_fail_bad_enum_val(caplog, config, config_file, schema, schema_file):
     # Specify an invalid enum value.
+    logging.getLogger().setLevel(logging.INFO)
     config["color"] = "yellow"
     write_as_json(config, config_file)
     write_as_json(schema, schema_file)
@@ -106,6 +110,7 @@ def test_validate_yaml_fail_bad_enum_val(caplog, config, config_file, schema, sc
 
 def test_validate_yaml_fail_bad_number_val(caplog, config, config_file, schema, schema_file):
     # Specify an invalid number value.
+    logging.getLogger().setLevel(logging.INFO)
     config["number"] = "string"
     write_as_json(config, config_file)
     write_as_json(schema, schema_file)

--- a/src/uwtools/tests/drivers/test_forecast.py
+++ b/src/uwtools/tests/drivers/test_forecast.py
@@ -2,6 +2,7 @@
 """
 Tests for forecast driver.
 """
+import logging
 import subprocess
 from pathlib import Path
 from unittest.mock import patch
@@ -306,6 +307,7 @@ def test_run_direct(fv3_run_assets):
 
 
 def test_FV3Forecast_run_dry_run(caplog, fv3_run_assets):
+    logging.getLogger().setLevel(logging.INFO)
     batch_script, config_file, config = fv3_run_assets
     run_expected = """
 #!/bin/bash

--- a/src/uwtools/tests/test_cli.py
+++ b/src/uwtools/tests/test_cli.py
@@ -254,21 +254,24 @@ def test__dispatch_config_validate_yaml():
 
 
 def test_dispath_config_validate_unsupported():
-    args = ns(input_file=1, input_format="jpg", schema_file=3)
+    args = ns()
+    vars(args).update({STR.infile: 1, STR.infmt: "jpg", STR.schemafile: 3})
     assert cli._dispatch_config_validate(args) is False
 
 
 @pytest.mark.parametrize("params", [(STR.run, "_dispatch_forecast_run")])
 def test__dispatch_forecast(params):
     submode, funcname = params
-    args = ns(submode=submode)
+    args = ns()
+    vars(args).update({STR.submode: submode})
     with patch.object(cli, funcname) as m:
         cli._dispatch_forecast(args)
     assert m.called_once_with(args)
 
 
 def test__dispatch_forecast_run():
-    args = ns(config_file=1, forecast_model="foo")
+    args = ns()
+    vars(args).update({STR.cfgfile: 1, "forecast_model": "foo"})
     with patch.object(cli.uwtools.drivers.forecast, "FooForecast", create=True) as m:
         CLASSES = {"foo": getattr(cli.uwtools.drivers.forecast, "FooForecast")}
         with patch.object(cli.uwtools.drivers.forecast, "CLASSES", new=CLASSES):
@@ -280,21 +283,25 @@ def test__dispatch_forecast_run():
 @pytest.mark.parametrize("params", [(STR.render, "_dispatch_template_render")])
 def test__dispatch_template(params):
     submode, funcname = params
-    args = ns(submode=submode)
+    args = ns()
+    vars(args).update({STR.submode: submode})
     with patch.object(cli, funcname) as m:
         cli._dispatch_template(args)
     assert m.called_once_with(args)
 
 
 def test__dispatch_template_render_yaml():
-    args = ns(
-        input_file=1,
-        output_file=2,
-        values_file=3,
-        values_format=4,
-        key_eq_val_pairs=["foo=88", "bar=99"],
-        values_needed=6,
-        dry_run=7,
+    args = ns()
+    vars(args).update(
+        {
+            STR.infile: 1,
+            STR.outfile: 2,
+            STR.valsfile: 3,
+            STR.valsfmt: 4,
+            STR.keyvalpairs: ["foo=88", "bar=99"],
+            STR.valsneeded: 6,
+            STR.dryrun: 7,
+        }
     )
     with patch.object(cli.uwtools.config.templater, STR.render) as m:
         cli._dispatch_template_render(args)

--- a/src/uwtools/tests/test_cli.py
+++ b/src/uwtools/tests/test_cli.py
@@ -1,6 +1,6 @@
 # pylint: disable=missing-function-docstring,protected-access,redefined-outer-name
 
-# import logging
+import logging
 from argparse import ArgumentParser as Parser
 from argparse import Namespace as ns
 from typing import List
@@ -68,25 +68,17 @@ def test__add_subparser_template_render(subparsers):
     assert subparsers.choices["render"]
 
 
-# def test__check_args_fail_quiet_verbose(capsys):
-#     logging.getLogger().setLevel(logging.INFO)
-#     args = ns(quiet=True, verbose=True)
-#     with raises(SystemExit):
-#         cli._check_args(args)
-#     assert "Specify at most one of --quiet, --verbose" in capsys.readouterr().err
+def test__check_quiet_vs_verbose_fail_quiet_verbose(capsys):
+    logging.getLogger().setLevel(logging.INFO)
+    args = ns(quiet=True, verbose=True)
+    with raises(SystemExit):
+        cli._check_quiet_vs_verbose(args)
+    assert "Specify at most one of --quiet, --verbose" in capsys.readouterr().err
 
 
-# def test__check_args_fail_values_file_no_value_format(capsys):
-#     logging.getLogger().setLevel(logging.INFO)
-#     args = ns(values_file="foo")
-#     with raises(SystemExit):
-#         cli._check_args(args)
-#     assert "Specify --values-format with --values-file" in capsys.readouterr().err
-
-
-# def test__check_args_ok():
-#     args = ns(foo=88)
-#     assert cli._check_args(args) == args
+def test__quiet_vs_verbose_ok():
+    args = ns(foo=88)
+    assert cli._check_quiet_vs_verbose(args) == args
 
 
 def test__dict_from_key_eq_val_strings():

--- a/src/uwtools/tests/test_cli.py
+++ b/src/uwtools/tests/test_cli.py
@@ -260,19 +260,26 @@ def test__set_formats_fail(capsys, vals):
     )
 
 
-# def test__set_formats_pass_explicit():
-#     # Accept explcitly-specified format, whatever it is.
-#     args = ns(input_file="/path/to/input.txt", input_format="jpg")
-#     args = cli._set_formats(args)
-#     assert args.input_format == "jpg"
+def test__set_formats_pass_explicit():
+    # Accept explcitly-specified format, whatever it is.
+    fmt = "jpg"
+    args = cli._check_file_vs_format(
+        file_arg="input_file",
+        format_arg="input_format",
+        args=ns(input_file="/path/to/input.txt", input_format=fmt),
+    )
+    assert args.input_format == "jpg"
 
 
-# @pytest.mark.parametrize("fmt", vars(FORMAT).keys())
-# def test__set_formats_pass_implicit(fmt):
-#     # The format is correctly deduced for a file with a known extension.
-#     args = ns(input_file=f"/path/to/input.{fmt}", input_format=None)
-#     args = cli._set_formats(args)
-#     assert args.input_format == vars(FORMAT)[fmt]
+@pytest.mark.parametrize("fmt", vars(FORMAT).keys())
+def test__set_formats_pass_implicit(fmt):
+    # The format is correctly deduced for a file with a known extension.
+    args = cli._check_file_vs_format(
+        file_arg="input_file",
+        format_arg="input_format",
+        args=ns(input_file=f"/path/to/input.{fmt}", input_format=None),
+    )
+    assert args.input_format == vars(FORMAT)[fmt]
 
 
 # Helper functions

--- a/src/uwtools/tests/test_cli.py
+++ b/src/uwtools/tests/test_cli.py
@@ -99,28 +99,33 @@ def test__check_file_vs_format_fail(capsys, vals):
 def test__check_file_vs_format_pass_explicit():
     # Accept explcitly-specified format, whatever it is.
     fmt = "jpg"
+    args = ns()
+    vars(args).update({STR.infile: "/path/to/input.txt", STR.infmt: fmt})
     args = cli._check_file_vs_format(
         file_arg=STR.infile,
         format_arg=STR.infmt,
-        args=ns(input_file="/path/to/input.txt", input_format=fmt),
+        args=args,
     )
-    assert args.input_format == "jpg"
+    assert args.input_format == fmt
 
 
 @pytest.mark.parametrize("fmt", vars(FORMAT).keys())
 def test__check_file_vs_format_pass_implicit(fmt):
     # The format is correctly deduced for a file with a known extension.
+    args = ns()
+    vars(args).update({STR.infile: f"/path/to/input.{fmt}", STR.infmt: None})
     args = cli._check_file_vs_format(
         file_arg=STR.infile,
         format_arg=STR.infmt,
-        args=ns(input_file=f"/path/to/input.{fmt}", input_format=None),
+        args=args,
     )
     assert args.input_format == vars(FORMAT)[fmt]
 
 
-def test__check_quiet_vs_verbose_fail_quiet_verbose(capsys):
+def test__check_quiet_vs_verbose_fail(capsys):
     logging.getLogger().setLevel(logging.INFO)
-    args = ns(quiet=True, verbose=True)
+    args = ns()
+    vars(args).update({STR.quiet: True, STR.verbose: True})
     with raises(SystemExit):
         cli._check_quiet_vs_verbose(args)
     assert (
@@ -182,14 +187,16 @@ def test__dict_from_key_eq_val_strings():
 )
 def test__dispatch_config(params):
     submode, funcname = params
-    args = ns(submode=submode)
+    args = ns()
+    vars(args).update({STR.submode: submode})
     with patch.object(cli, funcname) as m:
         cli._dispatch_config(args)
     assert m.called_once_with(args)
 
 
 def test__dispatch_config_compare():
-    args = ns(file_1_path=1, file_1_format=2, file_2_path=3, file_2_format=4)
+    args = ns()
+    vars(args).update({STR.file1path: 1, STR.file1fmt: 2, STR.file2path: 3, STR.file2fmt: 4})
     with patch.object(cli.uwtools.config.core, "compare_configs") as m:
         cli._dispatch_config_compare(args)
     assert m.called_once_with(args)

--- a/src/uwtools/tests/test_cli.py
+++ b/src/uwtools/tests/test_cli.py
@@ -74,26 +74,6 @@ def test__add_subparser_template_render(subparsers):
     assert subparsers.choices[STR.render]
 
 
-# @pytest.mark.parametrize(
-#     "vals",
-#     [
-#         (ns(file_1_path=None, file_1_format=None), STR.file1path, STR.file1fmt),
-#         (ns(file_2_path=None, file_2_format=None), STR.file2path, STR.file2fmt),
-#         (ns(input_file=None, input_format=None), STR.infile, STR.infmt),
-#         (ns(output_file=None, output_format=None), STR.outfile, STR.outfmt),
-#         (ns(values_file=None, values_format=None), STR.valsfile, STR.valsfmt),
-#     ],
-# )
-# def test__check_file_vs_format_fail(capsys, vals):
-#     # When reading/writing from/to stdin/stdout, the data format must be specified, since there is
-#     # no filename to deduce it from.
-#     args, file_arg, format_arg = vals
-#     with raises(SystemExit):
-#         cli._check_file_vs_format(file_arg=file_arg, format_arg=format_arg, args=args)
-#     assert (
-#         "Specify %s when %s is not specified" % (cli._arg2sw(format_arg), cli._arg2sw(file_arg))
-#         in capsys.readouterr().err
-#     )
 @pytest.mark.parametrize(
     "vals",
     [

--- a/src/uwtools/tests/test_cli.py
+++ b/src/uwtools/tests/test_cli.py
@@ -212,7 +212,7 @@ def test_main_fail(params):
     dispatch_retval, status, quiet, verbose = params
     with patch.multiple(cli, _parse_args=D, _dispatch_config=D, setup_logging=D) as mocks:
         args = ns(mode="config", submode="realize", quiet=quiet, verbose=verbose)
-        mocks["_parse_args"].return_value = args, {"config": {"realize": []}}
+        mocks["_parse_args"].return_value = args, {"config": {"realize": [lambda _: True]}}
         mocks["_dispatch_config"].return_value = dispatch_retval
         with raises(SystemExit) as e:
             cli.main()

--- a/src/uwtools/tests/test_cli.py
+++ b/src/uwtools/tests/test_cli.py
@@ -74,20 +74,42 @@ def test__add_subparser_template_render(subparsers):
     assert subparsers.choices[STR.render]
 
 
+# @pytest.mark.parametrize(
+#     "vals",
+#     [
+#         (ns(file_1_path=None, file_1_format=None), STR.file1path, STR.file1fmt),
+#         (ns(file_2_path=None, file_2_format=None), STR.file2path, STR.file2fmt),
+#         (ns(input_file=None, input_format=None), STR.infile, STR.infmt),
+#         (ns(output_file=None, output_format=None), STR.outfile, STR.outfmt),
+#         (ns(values_file=None, values_format=None), STR.valsfile, STR.valsfmt),
+#     ],
+# )
+# def test__check_file_vs_format_fail(capsys, vals):
+#     # When reading/writing from/to stdin/stdout, the data format must be specified, since there is
+#     # no filename to deduce it from.
+#     args, file_arg, format_arg = vals
+#     with raises(SystemExit):
+#         cli._check_file_vs_format(file_arg=file_arg, format_arg=format_arg, args=args)
+#     assert (
+#         "Specify %s when %s is not specified" % (cli._arg2sw(format_arg), cli._arg2sw(file_arg))
+#         in capsys.readouterr().err
+#     )
 @pytest.mark.parametrize(
     "vals",
     [
-        (ns(file_1_path=None, file_1_format=None), STR.file1path, STR.file1fmt),
-        (ns(file_2_path=None, file_2_format=None), STR.file2path, STR.file2fmt),
-        (ns(input_file=None, input_format=None), STR.infile, STR.infmt),
-        (ns(output_file=None, output_format=None), STR.outfile, STR.outfmt),
-        (ns(values_file=None, values_format=None), STR.valsfile, STR.valsfmt),
+        (STR.file1path, STR.file1fmt),
+        (STR.file2path, STR.file2fmt),
+        (STR.infile, STR.infmt),
+        (STR.outfile, STR.outfmt),
+        (STR.valsfile, STR.valsfmt),
     ],
 )
 def test__check_file_vs_format_fail(capsys, vals):
     # When reading/writing from/to stdin/stdout, the data format must be specified, since there is
     # no filename to deduce it from.
-    args, file_arg, format_arg = vals
+    file_arg, format_arg = vals
+    args = ns()
+    vars(args).update({file_arg: None, format_arg: None})
     with raises(SystemExit):
         cli._check_file_vs_format(file_arg=file_arg, format_arg=format_arg, args=args)
     assert (

--- a/src/uwtools/tests/test_cli.py
+++ b/src/uwtools/tests/test_cli.py
@@ -238,23 +238,26 @@ def test__parse_args():
         parser.parse_args.assert_called_with(raw_args)
 
 
-# @pytest.mark.parametrize(
-#     "vals",
-#     [
-#         (ns(file_1_path=None, file_1_format=None), "--file-1-path", "--file-1-format"),
-#         (ns(file_2_path=None, file_2_format=None), "--file-2-path", "--file-2-format"),
-#         (ns(input_file=None, input_format=None), "--input-file", "--input-format"),
-#         (ns(output_file=None, output_format=None), "--output-file", "--output-format"),
-#         (ns(values_file=None, values_format=None), "--values-file", "--values-format"),
-#     ],
-# )
-# def test__set_formats_fail(capsys, vals):
-#     # When reading/writing from/to stdin/stdout, the data format must be specified, since there is
-#     # no filename to deduce it from.
-#     args, path_arg, fmt_arg = vals
-#     with raises(SystemExit):
-#         cli._set_formats(args)
-#     assert f"Specify {fmt_arg} when {path_arg} is not specified" in capsys.readouterr().err
+@pytest.mark.parametrize(
+    "vals",
+    [
+        (ns(file_1_path=None, file_1_format=None), "file_1_path", "file_1_format"),
+        (ns(file_2_path=None, file_2_format=None), "file_2_path", "file_2_format"),
+        (ns(input_file=None, input_format=None), "input_file", "input_format"),
+        (ns(output_file=None, output_format=None), "output_file", "output_format"),
+        (ns(values_file=None, values_format=None), "values_file", "values_format"),
+    ],
+)
+def test__set_formats_fail(capsys, vals):
+    # When reading/writing from/to stdin/stdout, the data format must be specified, since there is
+    # no filename to deduce it from.
+    args, file_arg, format_arg = vals
+    with raises(SystemExit):
+        cli._check_file_vs_format(file_arg=file_arg, format_arg=format_arg, args=args)
+    assert (
+        "Specify %s when %s is not specified" % (cli._arg2sw(format_arg), cli._arg2sw(file_arg))
+        in capsys.readouterr().err
+    )
 
 
 # def test__set_formats_pass_explicit():

--- a/src/uwtools/tests/test_cli.py
+++ b/src/uwtools/tests/test_cli.py
@@ -1,6 +1,6 @@
 # pylint: disable=missing-function-docstring,protected-access,redefined-outer-name
 
-import logging
+# import logging
 from argparse import ArgumentParser as Parser
 from argparse import Namespace as ns
 from typing import List
@@ -68,25 +68,25 @@ def test__add_subparser_template_render(subparsers):
     assert subparsers.choices["render"]
 
 
-def test__check_args_fail_quiet_verbose(capsys):
-    logging.getLogger().setLevel(logging.INFO)
-    args = ns(quiet=True, verbose=True)
-    with raises(SystemExit):
-        cli._check_args(args)
-    assert "Specify at most one of --quiet, --verbose" in capsys.readouterr().err
+# def test__check_args_fail_quiet_verbose(capsys):
+#     logging.getLogger().setLevel(logging.INFO)
+#     args = ns(quiet=True, verbose=True)
+#     with raises(SystemExit):
+#         cli._check_args(args)
+#     assert "Specify at most one of --quiet, --verbose" in capsys.readouterr().err
 
 
-def test__check_args_fail_values_file_no_value_format(capsys):
-    logging.getLogger().setLevel(logging.INFO)
-    args = ns(values_file="foo")
-    with raises(SystemExit):
-        cli._check_args(args)
-    assert "Specify --values-format with --values-file" in capsys.readouterr().err
+# def test__check_args_fail_values_file_no_value_format(capsys):
+#     logging.getLogger().setLevel(logging.INFO)
+#     args = ns(values_file="foo")
+#     with raises(SystemExit):
+#         cli._check_args(args)
+#     assert "Specify --values-format with --values-file" in capsys.readouterr().err
 
 
-def test__check_args_ok():
-    args = ns(foo=88)
-    assert cli._check_args(args) == args
+# def test__check_args_ok():
+#     args = ns(foo=88)
+#     assert cli._check_args(args) == args
 
 
 def test__dict_from_key_eq_val_strings():
@@ -242,38 +242,38 @@ def test__parse_args():
         parser.parse_args.assert_called_with(raw_args)
 
 
-@pytest.mark.parametrize(
-    "vals",
-    [
-        (ns(file_1_path=None, file_1_format=None), "--file-1-path", "--file-1-format"),
-        (ns(file_2_path=None, file_2_format=None), "--file-2-path", "--file-2-format"),
-        (ns(input_file=None, input_format=None), "--input-file", "--input-format"),
-        (ns(output_file=None, output_format=None), "--output-file", "--output-format"),
-        (ns(values_file=None, values_format=None), "--values-file", "--values-format"),
-    ],
-)
-def test__set_formats_fail(capsys, vals):
-    # When reading/writing from/to stdin/stdout, the data format must be specified, since there is
-    # no filename to deduce it from.
-    args, path_arg, fmt_arg = vals
-    with raises(SystemExit):
-        cli._set_formats(args)
-    assert f"Specify {fmt_arg} when {path_arg} is not specified" in capsys.readouterr().err
+# @pytest.mark.parametrize(
+#     "vals",
+#     [
+#         (ns(file_1_path=None, file_1_format=None), "--file-1-path", "--file-1-format"),
+#         (ns(file_2_path=None, file_2_format=None), "--file-2-path", "--file-2-format"),
+#         (ns(input_file=None, input_format=None), "--input-file", "--input-format"),
+#         (ns(output_file=None, output_format=None), "--output-file", "--output-format"),
+#         (ns(values_file=None, values_format=None), "--values-file", "--values-format"),
+#     ],
+# )
+# def test__set_formats_fail(capsys, vals):
+#     # When reading/writing from/to stdin/stdout, the data format must be specified, since there is
+#     # no filename to deduce it from.
+#     args, path_arg, fmt_arg = vals
+#     with raises(SystemExit):
+#         cli._set_formats(args)
+#     assert f"Specify {fmt_arg} when {path_arg} is not specified" in capsys.readouterr().err
 
 
-def test__set_formats_pass_explicit():
-    # Accept explcitly-specified format, whatever it is.
-    args = ns(input_file="/path/to/input.txt", input_format="jpg")
-    args = cli._set_formats(args)
-    assert args.input_format == "jpg"
+# def test__set_formats_pass_explicit():
+#     # Accept explcitly-specified format, whatever it is.
+#     args = ns(input_file="/path/to/input.txt", input_format="jpg")
+#     args = cli._set_formats(args)
+#     assert args.input_format == "jpg"
 
 
-@pytest.mark.parametrize("fmt", vars(FORMAT).keys())
-def test__set_formats_pass_implicit(fmt):
-    # The format is correctly deduced for a file with a known extension.
-    args = ns(input_file=f"/path/to/input.{fmt}", input_format=None)
-    args = cli._set_formats(args)
-    assert args.input_format == vars(FORMAT)[fmt]
+# @pytest.mark.parametrize("fmt", vars(FORMAT).keys())
+# def test__set_formats_pass_implicit(fmt):
+#     # The format is correctly deduced for a file with a known extension.
+#     args = ns(input_file=f"/path/to/input.{fmt}", input_format=None)
+#     args = cli._set_formats(args)
+#     assert args.input_format == vars(FORMAT)[fmt]
 
 
 # Helper functions

--- a/src/uwtools/tests/test_cli.py
+++ b/src/uwtools/tests/test_cli.py
@@ -4,6 +4,7 @@ import logging
 import sys
 from argparse import ArgumentParser as Parser
 from argparse import Namespace as ns
+from argparse import _SubParsersAction
 from typing import List
 from unittest.mock import patch
 
@@ -363,12 +364,10 @@ def test__parse_args():
 
 
 def submodes(parser: Parser) -> List[str]:
-    # Return submodes (named subparsers) belonging to the given parser.
-    if subparsers := parser._subparsers:
-        if action := subparsers._actions[1]:
-            if choices := action.choices:
-                submodes = choices.keys()  # type: ignore
-                return list(submodes)
+    # Return submodes (named subparsers) belonging to the given parser. For some background, see
+    # https://stackoverflow.com/questions/43688450.
+    if actions := [x for x in parser._actions if isinstance(x, _SubParsersAction)]:
+        return list(actions[0].choices.keys())
     return []
 
 

--- a/src/uwtools/tests/test_cli.py
+++ b/src/uwtools/tests/test_cli.py
@@ -93,7 +93,7 @@ def test__check_file_vs_format_fail(capsys, vals):
     with raises(SystemExit):
         cli._check_file_vs_format(file_arg=file_arg, format_arg=format_arg, args=args)
     assert (
-        "Specify %s when %s is not specified" % (cli._arg2sw(format_arg), cli._arg2sw(file_arg))
+        "Specify %s when %s is not specified" % (cli._switch(format_arg), cli._switch(file_arg))
         in capsys.readouterr().err
     )
 
@@ -131,7 +131,7 @@ def test__check_quiet_vs_verbose_fail(capsys):
     with raises(SystemExit):
         cli._check_quiet_vs_verbose(args)
     assert (
-        "Specify at most one of %s, %s" % (cli._arg2sw(STR.quiet), cli._arg2sw(STR.verbose))
+        "Specify at most one of %s, %s" % (cli._switch(STR.quiet), cli._switch(STR.verbose))
         in capsys.readouterr().err
     )
 
@@ -316,9 +316,9 @@ def test_main_fail_checks(capsys, quiet, verbose):
     # Using mode 'template render' for testing.
     raw_args = ["testing", STR.template, STR.render]
     if quiet:
-        raw_args.append(cli._arg2sw(STR.quiet))
+        raw_args.append(cli._switch(STR.quiet))
     if verbose:
-        raw_args.append(cli._arg2sw(STR.verbose))
+        raw_args.append(cli._switch(STR.verbose))
     with patch.object(sys, "argv", raw_args):
         with patch.object(cli, "_dispatch_template", return_value=True):
             with raises(SystemExit) as e:

--- a/src/uwtools/tests/test_cli.py
+++ b/src/uwtools/tests/test_cli.py
@@ -203,15 +203,18 @@ def test__dispatch_config_compare():
 
 
 def test__dispatch_config_realize():
-    args = ns(
-        input_file=1,
-        input_format=2,
-        output_file=3,
-        output_format=4,
-        values_file=5,
-        values_format=6,
-        values_needed=7,
-        dry_run=8,
+    args = ns()
+    vars(args).update(
+        {
+            STR.infile: 1,
+            STR.infmt: 2,
+            STR.outfile: 3,
+            STR.outfmt: 4,
+            STR.valsfile: 5,
+            STR.valsfmt: 6,
+            STR.valsneeded: 7,
+            STR.dryrun: 8,
+        }
     )
     with patch.object(cli.uwtools.config.core, "realize_config") as m:
         cli._dispatch_config_realize(args)
@@ -219,12 +222,15 @@ def test__dispatch_config_realize():
 
 
 def test__dispatch_config_translate_arparse_to_jinja2():
-    args = ns(
-        input_file=1,
-        input_format=FORMAT.atparse,
-        output_file=3,
-        output_format=FORMAT.jinja2,
-        dry_run=5,
+    args = ns()
+    vars(args).update(
+        {
+            STR.infile: 1,
+            STR.infmt: FORMAT.atparse,
+            STR.outfile: 3,
+            STR.outfmt: FORMAT.jinja2,
+            STR.dryrun: 5,
+        }
     )
     with patch.object(cli.uwtools.config.atparse_to_jinja2, "convert") as m:
         cli._dispatch_config_translate(args)
@@ -232,12 +238,16 @@ def test__dispatch_config_translate_arparse_to_jinja2():
 
 
 def test_dispath_config_translate_unsupported():
-    args = ns(input_file=1, input_format="jpg", output_file=3, output_format="png", dry_run=5)
+    args = ns()
+    vars(args).update(
+        {STR.infile: 1, STR.infmt: "jpg", STR.outfile: 3, STR.outfmt: "png", STR.dryrun: 5}
+    )
     assert cli._dispatch_config_translate(args) is False
 
 
 def test__dispatch_config_validate_yaml():
-    args = ns(input_file=1, input_format=FORMAT.yaml, schema_file=3)
+    args = ns()
+    vars(args).update({STR.infile: 1, STR.infmt: FORMAT.yaml, STR.schemafile: 3})
     with patch.object(cli.uwtools.config.validator, "validate_yaml") as m:
         cli._dispatch_config_validate(args)
     assert m.called_once_with(args)


### PR DESCRIPTION
**Description**

I discovered some discrepancies in how arguments should be treated in various modes that made the idea of a single function to do all final checks on parsed arguments look infeasible. For example, under `uw config realize`, `--values-format` is mandatory if `--values-file` is not defined (because `uw` cannot know how it should interpret data appearing on `stdin`), or when the format cannot be deduced from a given `--values-file` argument. But under `uw template render`, `--values-format` is **not** mandatory even if `--values-file` is not defined, because the user's intent might be to use values from the environment or from key-value pairs provided on the command line; but `--values-format` **is** mandatory if `--values-file` is specified but its format cannot be deduced from the provided filename. So, in short, final validation of arguments is probably going to depend on the particular semantics of each mode.

To support that, this PR delegates the definition of those checks to each mode, so that the checks are defined in the same place as the arguments themselves. After the arguments are parsed, the checks that the selected [sub]mode specifies are carried out on the arguments.

This PR also introduces a container for canonical string values used in the CLI, to avoid repetition of hard-to-check magic string values.

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**

Passes `make test` locally, plus GitHub Actions.

**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [x] Any dependent changes have been merged and published
