### PR TITLE
meta.json-and-pip-deps

### DIFF
--- a/recipe/.gitignore
+++ b/recipe/.gitignore
@@ -1,1 +1,0 @@
-meta.json

--- a/recipe/README.md
+++ b/recipe/README.md
@@ -1,0 +1,3 @@
+Do not manually edit meta.json.
+
+If meta.yaml changes, regenerate meta.json by running "make meta" in the clone root, from a shell with conda activated and the "condev" package installed (i.e. not a development shell). Commit the updated meta.json file.

--- a/recipe/README.md
+++ b/recipe/README.md
@@ -1,3 +1,5 @@
-Do not manually edit meta.json.
+Do not manually edit `meta.json`.
 
-If meta.yaml changes, regenerate meta.json by running "make meta" in the clone root, from a shell with conda activated and the "condev" package installed (i.e. not a development shell). Commit the updated meta.json file.
+If `meta.yaml` or `conda_build_config.yaml` (which it depends on) change, regenerate `meta.json` by running `make meta` in the git clone root, from a shell with conda activated and the `condev` package installed (i.e. not a development shell). Commit the updated `meta.json` file.
+
+A `make devshell` command may also automatically update `meta.json` if its dependencies have changed.

--- a/recipe/README.md
+++ b/recipe/README.md
@@ -2,4 +2,4 @@ Do not manually edit `meta.json`.
 
 If `meta.yaml` or `conda_build_config.yaml` (which it depends on) change, regenerate `meta.json` by running `make meta` in the git clone root, from a shell with conda activated and the `condev` package installed (i.e. not a development shell). Commit the updated `meta.json` file.
 
-A `make devshell` command may also automatically update `meta.json` if its dependencies have changed.
+A `make devshell` command will also automatically update `meta.json` if its dependencies have changed.

--- a/recipe/meta.json
+++ b/recipe/meta.json
@@ -1,0 +1,34 @@
+{
+  "build": "pyh28a5fc4_0",
+  "buildnum": "0",
+  "name": "uwtools",
+  "packages": {
+    "dev": [
+      "black =23.3.*",
+      "boto3 =1.22.*",
+      "coverage =7.2.*",
+      "docformatter =1.7.*",
+      "f90nml =1.4.*",
+      "isort =5.12.*",
+      "jinja2 =3.0.*",
+      "jsonschema =4.17.*",
+      "lxml =4.9.*",
+      "mypy =1.4.*",
+      "pip",
+      "pylint =2.17.*",
+      "pytest =7.4.*",
+      "python =3.11",
+      "pyyaml =6.0.*"
+    ],
+    "run": [
+      "boto3 =1.22.*",
+      "f90nml =1.4.*",
+      "jinja2 =3.0.*",
+      "jsonschema =4.17.*",
+      "lxml =4.9.*",
+      "python =3.11",
+      "pyyaml =6.0.*"
+    ]
+  },
+  "version": "1.0.0"
+}

--- a/src/setup.py
+++ b/src/setup.py
@@ -24,12 +24,14 @@ with open(os.path.join(recipe, "meta.json"), "r", encoding="utf-8") as f:
 name_conda = meta["name"]
 name_py = name_conda.replace("-", "_")
 
-setup(
-    entry_points={"console_scripts": ["uw = %s.cli:main" % name_py]},
-    name=name_conda,
-    packages=find_packages(
-        exclude=["%s.tests" % name_py],
-        include=[name_py, "%s.*" % name_py],
-    ),
-    version=meta["version"],
-)
+kwargs = {
+    "entry_points": {"console_scripts": ["uw = %s.cli:main" % name_py]},
+    "name": name_conda,
+    "packages": find_packages(exclude=["%s.tests" % name_py], include=[name_py, "%s.*" % name_py]),
+    "version": meta["version"],
+}
+
+if not os.environ.get("CONDA_PREFIX"):
+    kwargs["install_requires"] = [x.replace(" =", "==") for x in meta["packages"]["run"]]
+
+setup(**kwargs)

--- a/src/setup.py
+++ b/src/setup.py
@@ -1,19 +1,19 @@
 """
 Basic setuptools configuration.
 
-See https://setuptools.pypa.io/en/latest/userguide/quickstart.html#basic-use for
-information on this standard setuptools file.
+See https://setuptools.pypa.io/en/latest/userguide/quickstart.html#basic-use for information on
+this standard setuptools file.
 
-In this codebase, it is used 1. By conda-build to install the uwtools files into
-the package tree, and 2. By condev-shell (called by "make devshell") to perform
-an "editable" install into the conda development environment, such that source
-files in the clone are live-linked into the conda environment so that they can
-be executed in a context where all build/run/test dependency packages are
-available.
+Here it is used 1. By conda-build to install the uwtools files into the package tree; 2. By "make
+devshell" to perform an "editable" install into the conda development environment, such that source
+files in the clone are live-linked into the conda environment so that they can be executed in a
+context where all build/run/test dependency packages are available; and 3. By pip users to install
+the local package along with its dependencies from PyPI.
 """
 
 import json
 import os
+import re
 
 from setuptools import find_packages, setup  # type: ignore
 
@@ -32,6 +32,10 @@ kwargs = {
 }
 
 if not os.environ.get("CONDA_PREFIX"):
-    kwargs["install_requires"] = [x.replace(" =", "==") for x in meta["packages"]["run"]]
+    kwargs["install_requires"] = [
+        pkg.replace(" =", "==")
+        for pkg in meta["packages"]["run"]
+        if not re.match(r"^python .*$", pkg)
+    ]
 
 setup(**kwargs)


### PR DESCRIPTION
Commit `recipe/meta.json` to git to support easier installation for end users until we are able to provide pre-built packages.