### PR TITLE
uw-246

### DIFF
--- a/.github/scripts/tag-check
+++ b/.github/scripts/tag-check
@@ -1,0 +1,8 @@
+#!/bin/bash -eux
+
+f=recipe/meta.json
+tag=v$(jq -r .version $f)-$(jq -r .buildnum $f)
+if git ls-remote --tags origin | grep -q "/$tag$"; then
+  (set +x && echo TAG $tag ALREADY EXISTS)
+  exit 1
+fi

--- a/.github/scripts/tag-create
+++ b/.github/scripts/tag-create
@@ -1,0 +1,6 @@
+#!/bin/bash -eux
+
+f=recipe/meta.json
+tag=v$(jq -r .version $f)-$(jq -r .buildnum $f)
+git tag $tag
+git push --tags

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,17 @@
+name: release
+env:
+  GH_TOKEN: ${{ github.token }}
+on:
+  push:
+    branches:
+      - main
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Check For Existing Tag
+        run:  .github/scripts/tag-check
+      - name: Tag
+        run: .github/scripts/tag-create

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,6 +1,4 @@
 name: release
-env:
-  GH_TOKEN: ${{ github.token }}
 on:
   push:
     branches:


### PR DESCRIPTION
**Description**

Add a `release` GitHub Actions workflow to support (initially) tagging the repo based on the `uwtools` version number when merges to the (new) `main` branch occur. In future work (e.g. in [UW-317](https://jira.epic.oarcloud.noaa.gov/browse/UW-317)) we can add steps to the `release` workflow to 1. build the `uwtools` conda package and 2. stage it to the [ufs-community](https://anaconda.org/ufs-community/uwtools) channel on anaconda.org before executing the tagging steps here.

**Type of change**

- [x] New feature (non-breaking change which adds functionality)

**How Has This Been Tested?**

I'm not sure it's possible to really test this except in situ. However, what's being added here is based on [two](https://github.com/maddenp/condev/blob/main/.github/scripts/tag-check) [scripts](https://github.com/maddenp/condev/blob/main/.github/scripts/tag-create) and a [workflow](https://github.com/maddenp/condev/blob/main/.github/workflows/ci.yml) from the [condev](https://github.com/maddenp/condev) repo, which have been working for some time. It's possible that I might need to do a post-merge push if something doesn't work as expected, but I feel fairly confident.