### PR TITLE
UW 322 as a user, I would like to validate my rocoto xml workflow, given the rocoto native schema

### DIFF
--- a/src/uwtools/cli.py
+++ b/src/uwtools/cli.py
@@ -15,6 +15,8 @@ from importlib import resources
 from pathlib import Path
 from typing import Callable, Dict, List, Tuple
 
+from lxml import etree
+
 import uwtools.config.atparse_to_jinja2
 import uwtools.config.core
 import uwtools.config.templater
@@ -422,6 +424,14 @@ def _dispatch_rocoto_validate(args: Namespace) -> bool:
         )
     else:
         success = False
+    if args.verbose: #pragma: no cover
+        errors = str(etree.RelaxNG.error_log).split("\n")
+        log_method = logging.error if len(errors) else logging.info
+        log_method(
+            "%s Rocoto validation error%s found", len(errors), "" if len(errors) == 1 else "s"
+        )
+        for line in errors:
+            logging.error(line)
     return success
 
 

--- a/src/uwtools/cli.py
+++ b/src/uwtools/cli.py
@@ -11,7 +11,6 @@ from argparse import _ArgumentGroup as Group
 from argparse import _SubParsersAction as Subparsers
 from dataclasses import dataclass
 from functools import partial
-from importlib import resources
 from pathlib import Path
 from typing import Callable, Dict, List, Tuple
 
@@ -307,7 +306,7 @@ def _dispatch_forecast_run(args: Namespace) -> bool:
     )
 
 
-# Mode Rocoto
+# Mode rocoto
 
 
 def _add_subparser_rocoto(subparsers: Subparsers) -> ModeChecks:
@@ -386,12 +385,8 @@ def _dispatch_rocoto_validate(args: Namespace) -> bool:
 
     :param args: Parsed command-line args.
     """
-    with resources.as_file(resources.files("uwtools.resources")) as resc:
-        rocoto_schema = resc / "rocoto.jsonschema"
 
-    success = uwtools.rocoto.validate_rocoto_xml(
-        input_xml=args.input_file, schema_file=rocoto_schema
-    )
+    success = uwtools.rocoto.validate_rocoto_xml(input_xml=args.input_file)
     return success
 
 

--- a/src/uwtools/cli.py
+++ b/src/uwtools/cli.py
@@ -379,17 +379,27 @@ def _dispatch_rocoto(args: Namespace) -> bool:
 
 def _dispatch_rocoto_write(args: Namespace) -> bool:
     """
-    Dispatch logic for rocoto write submode.
+    Dispatch logic for rocoto write submode. Validate input and output.
 
     :param args: Parsed command-line args.
     """
     success = True
     if args.input_format == FORMAT.yaml and args.output_format == FORMAT.rocoto:
-        uwtools.rocoto.write_rocoto_xml(
-            input_yaml=args.input_file,
-            input_template=str(args.schema_file),
-            rendered_output=str(args.output_file),
+        valid_input = uwtools.config.validator.validate_yaml(
+            config_file=args.input_file, schema_file=args.schema_file
         )
+        if valid_input:
+            uwtools.rocoto.write_rocoto_xml(
+                input_yaml=args.input_file,
+                input_template=str(args.schema_file),
+                rendered_output=str(args.output_file),
+            )
+        else:
+            success = False
+        valid_output = uwtools.rocoto.validate_rocoto_xml(
+            input_xml=args.output_file, schema_file=args.schema_file
+        )
+        success = False if not valid_output else success
     else:
         success = False
     return success

--- a/src/uwtools/cli.py
+++ b/src/uwtools/cli.py
@@ -337,10 +337,7 @@ def _add_subparser_rocoto_realize(subparsers: Subparsers) -> SubmodeChecks:
     _add_arg_output_file(required)
     optional = _basic_setup(parser)
     checks = _add_args_quiet_and_verbose(optional)
-    return checks + [
-        partial(_check_file_vs_format, STR.infile, FORMAT.yaml),
-        partial(_check_file_vs_format, STR.outfile, FORMAT.rocoto),
-    ]
+    return checks
 
 
 def _add_subparser_rocoto_validate(subparsers: Subparsers) -> SubmodeChecks:
@@ -354,9 +351,7 @@ def _add_subparser_rocoto_validate(subparsers: Subparsers) -> SubmodeChecks:
     _add_arg_input_file(required)
     optional = _basic_setup(parser)
     checks = _add_args_quiet_and_verbose(optional)
-    return checks + [
-        partial(_check_file_vs_format, STR.infile, FORMAT.rocoto),
-    ]
+    return checks
 
 
 def _dispatch_rocoto(args: Namespace) -> bool:
@@ -380,7 +375,7 @@ def _dispatch_rocoto_realize(args: Namespace) -> bool:
     :param args: Parsed command-line args.
     """
     success = uwtools.rocoto.realize_rocoto_xml(
-        input_yaml=args.input_file, rendered_output=str(args.output_file)
+        input_yaml=args.input_file, rendered_output=args.output_file
     )
     return success
 
@@ -395,7 +390,7 @@ def _dispatch_rocoto_validate(args: Namespace) -> bool:
         rocoto_schema = resc / "rocoto.jsonschema"
 
     success = uwtools.rocoto.validate_rocoto_xml(
-        input_xml=args.input_file, schema_file=str(rocoto_schema)
+        input_xml=args.input_file, schema_file=rocoto_schema
     )
     return success
 
@@ -824,7 +819,6 @@ class _STR:
     valsfmt: str = "values_format"
     valsneeded: str = "values_needed"
     verbose: str = "verbose"
-    write: str = "write"
 
 
 STR = _STR()

--- a/src/uwtools/cli.py
+++ b/src/uwtools/cli.py
@@ -332,12 +332,12 @@ def _add_subparser_rocoto_write(subparsers: Subparsers) -> SubmodeChecks:
     """
     parser = _add_subparser(subparsers, STR.write, "Write a Rocoto XML workflow document")
     required = parser.add_argument_group(TITLE_REQ_ARG)
-    optional = _basic_setup(parser)
     _add_arg_input_file(required)
-    _add_arg_input_format(optional, choices=[FORMAT.yaml])
     _add_arg_schema_file(required)
     _add_arg_output_file(required)
-    _add_arg_output_format(optional, choices=[FORMAT.rocoto])
+    optional = _basic_setup(parser)
+    _add_arg_input_format(optional, choices=[FORMAT.yaml])
+    _add_arg_output_format(optional, choices=[FORMAT.jinja2])
     checks = _add_args_quiet_and_verbose(optional)
     return checks + [
         partial(_check_file_vs_format, STR.infile, STR.infmt),
@@ -355,8 +355,7 @@ def _add_subparser_rocoto_validate(subparsers: Subparsers) -> SubmodeChecks:
     required = parser.add_argument_group(TITLE_REQ_ARG)
     _add_arg_input_file(required)
     optional = _basic_setup(parser)
-    _add_arg_input_format(optional, choices=[FORMAT.rocoto])
-    _add_arg_verbose(optional)
+    _add_arg_input_format(optional, choices=[FORMAT.jinja2])
     checks = _add_args_quiet_and_verbose(optional)
     return checks + [
         partial(_check_file_vs_format, STR.infile, STR.infmt),
@@ -384,7 +383,7 @@ def _dispatch_rocoto_write(args: Namespace) -> bool:
     :param args: Parsed command-line args.
     """
     success = True
-    if args.input_format == FORMAT.yaml and args.output_format == FORMAT.rocoto:
+    if args.input_format == FORMAT.yaml and args.output_format == FORMAT.jinja2:
         valid_input = uwtools.config.validator.validate_yaml(
             config_file=args.input_file, schema_file=args.schema_file
         )
@@ -413,7 +412,7 @@ def _dispatch_rocoto_validate(args: Namespace) -> bool:
     """
 
     success = True
-    if args.input_format == FORMAT.xml:
+    if args.input_format == FORMAT.jinja2:
         success = uwtools.rocoto.validate_rocoto_xml(
             input_xml=args.input_file, schema_file=args.schema_file
         )

--- a/src/uwtools/cli.py
+++ b/src/uwtools/cli.py
@@ -374,7 +374,7 @@ def _dispatch_rocoto_realize(args: Namespace) -> bool:
     :param args: Parsed command-line args.
     """
     success = uwtools.rocoto.realize_rocoto_xml(
-        input_yaml=args.input_file, rendered_output=args.output_file
+        config_file=args.input_file, rendered_output=args.output_file
     )
     return success
 

--- a/src/uwtools/cli.py
+++ b/src/uwtools/cli.py
@@ -332,9 +332,9 @@ def _add_subparser_rocoto_realize(subparsers: Subparsers) -> SubmodeChecks:
     """
     parser = _add_subparser(subparsers, STR.realize, "Realize a Rocoto XML workflow document")
     required = parser.add_argument_group(TITLE_REQ_ARG)
-    _add_arg_input_file(required)
     _add_arg_output_file(required)
     optional = _basic_setup(parser)
+    _add_arg_input_file(optional)
     checks = _add_args_quiet_and_verbose(optional)
     return checks
 
@@ -346,9 +346,8 @@ def _add_subparser_rocoto_validate(subparsers: Subparsers) -> SubmodeChecks:
     :param subparsers: Parent parser's subparsers, to add this subparser to.
     """
     parser = _add_subparser(subparsers, STR.validate, "Validate Rocoto XML")
-    required = parser.add_argument_group(TITLE_REQ_ARG)
-    _add_arg_input_file(required)
     optional = _basic_setup(parser)
+    _add_arg_input_file(optional)
     checks = _add_args_quiet_and_verbose(optional)
     return checks
 

--- a/src/uwtools/config/j2template.py
+++ b/src/uwtools/config/j2template.py
@@ -8,6 +8,9 @@ from typing import List, Optional, Set
 
 from jinja2 import BaseLoader, Environment, FileSystemLoader, Template, meta
 
+from uwtools.types import DefinitePath, OptionalPath
+from uwtools.utils.file import readable
+
 
 class J2Template:
     """
@@ -17,7 +20,7 @@ class J2Template:
     def __init__(
         self,
         values: dict,
-        template_path: Optional[str] = None,
+        template_path: OptionalPath = None,
         template_str: Optional[str] = None,
         **kwargs,
     ) -> None:
@@ -40,7 +43,7 @@ class J2Template:
 
     # Public methods
 
-    def dump(self, output_path: str) -> None:
+    def dump(self, output_path: DefinitePath) -> None:
         """
         Write rendered template to the path provided.
 
@@ -70,13 +73,13 @@ class J2Template:
             j2_parsed = self._j2env.parse(self._template_str)
         else:
             assert self._template_path is not None
-            with open(self._template_path, encoding="utf-8") as file_:
+            with readable(self._template_path) as file_:
                 j2_parsed = self._j2env.parse(file_.read())
         return meta.find_undeclared_variables(j2_parsed)
 
     # Private methods
 
-    def _load_file(self, template_path: str) -> Template:
+    def _load_file(self, template_path: OptionalPath) -> Template:
         """
         Load the Jinja2 template from the file provided.
 
@@ -85,7 +88,7 @@ class J2Template:
         """
         self._j2env = Environment(loader=FileSystemLoader(searchpath="/"))
         _register_filters(self._j2env)
-        return self._j2env.get_template(template_path)
+        return self._j2env.get_template(str(template_path))
 
     def _load_string(self, template: str) -> Template:
         """

--- a/src/uwtools/resources/rocoto.jinja2
+++ b/src/uwtools/resources/rocoto.jinja2
@@ -62,14 +62,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE workflow [
 
-{%- for entity, value in entities.items() %}
+{%- for entity, value in workflow.entities.items() %}
   <!ENTITY {{ entity }} "{{ value }}">
 {%- endfor %}
 
 ]>
-<workflow {% for attr, val in attrs.items() %}{{ attr }}="{{ val }}" {% endfor %}>
+<workflow {% for attr, val in workflow.attrs.items() %}{{ attr }}="{{ val }}" {% endfor %}>
 
-  {%- for group, cdefs in cycledefs.items() %}
+  {%- for group, cdefs in workflow.cycledefs.items() %}
     {%- for cdef in cdefs %}
   <cycledef group="{{ group }}">{{ cdef }}</cycledef>
     {%- endfor %}
@@ -77,7 +77,7 @@
 
   <log>{{ log }}</log>
 
-{%- for item, settings in tasks.items() %}
+{%- for item, settings in workflow.tasks.items() %}
   {%- if item.split("_", 1)[0] == "task" %}
   {{ task(name=item.split("_", 1)[-1], settings=settings ) }}
   {%- elif item.split("_", 1)[0] == "metatask" %}

--- a/src/uwtools/resources/rocoto.jinja2
+++ b/src/uwtools/resources/rocoto.jinja2
@@ -75,7 +75,7 @@
     {%- endfor %}
   {%- endfor %}
 
-  <log>{{ log }}</log>
+  <log>{{ workflow.log }}</log>
 
 {%- for item, settings in workflow.tasks.items() %}
   {%- if item.split("_", 1)[0] == "task" %}

--- a/src/uwtools/resources/rocoto.jsonschema
+++ b/src/uwtools/resources/rocoto.jsonschema
@@ -171,10 +171,10 @@
       "maxProperties": 3,
       "minProperties": 2,
       "patternProperties": {
-        "^metatask(_[a-z0-9_]+)?$": {
+        "^metatask(_.*)?$": {
           "$ref": "#/$defs/metatask"
         },
-        "^task(_[a-z0-9_]+)?$": {
+        "^task(_.*)?$": {
           "$ref": "#/$defs/task"
         }
       },
@@ -279,7 +279,7 @@
         "dependency": {
           "$ref": "#/$defs/dependency"
         },
-        "envar": {
+        "envars": {
           "type": "object"
         },
         "exclusive": {
@@ -407,10 +407,10 @@
           "additionalProperties": false,
           "minProperties": 1,
           "patternProperties": {
-            "^metatask(_[a-z0-9_]+)?$": {
+            "^metatask(_.*)?$": {
               "$ref": "#/$defs/metatask"
             },
-            "^task(_[a-z0-9_]+)?$": {
+            "^task(_.*)?$": {
               "$ref": "#/$defs/task"
             }
           },

--- a/src/uwtools/rocoto.py
+++ b/src/uwtools/rocoto.py
@@ -13,7 +13,6 @@ import uwtools.config.validator
 from uwtools.config.core import YAMLConfig
 from uwtools.config.j2template import J2Template
 from uwtools.types import OptionalPath
-from uwtools.utils.file import readable
 
 # Private functions
 
@@ -49,7 +48,7 @@ def _add_tasks(
         _add_jobname(tasks)
 
 
-def _rocoto_schema() -> str:
+def _rocoto_schema_yaml() -> str:
     """
     The path to the file containing the schema to validate the XML file against.
     """
@@ -57,7 +56,7 @@ def _rocoto_schema() -> str:
         return (path / "rocoto.jsonschema").as_posix()
 
 
-def _rocoto_template() -> str:
+def _rocoto_schema_xml() -> str:
     """
     The path to the file containing the Rocoto workflow document template to render.
     """
@@ -76,7 +75,7 @@ def _write_rocoto_xml(
     :param rendered_output: Path to write rendered XML file.
     """
 
-    rocoto_template = _rocoto_template()
+    rocoto_template = _rocoto_schema_xml()
     _add_tasks(config_file)
 
     # Render the template.
@@ -97,7 +96,7 @@ def realize_rocoto_xml(
     :param rendered_output: Path to write rendered XML file.
     """
 
-    rocoto_schema = _rocoto_schema()
+    rocoto_schema = _rocoto_schema_yaml()
 
     # Validate the YAML.
     if uwtools.config.validator.validate_yaml(config_file=config_file, schema_file=rocoto_schema):
@@ -125,10 +124,10 @@ def validate_rocoto_xml(input_xml: OptionalPath = None) -> bool:
 
     :param input_xml: Path to rendered XML file.
     """
-    rocoto_template = _rocoto_template()
+    rocoto_template = _rocoto_schema_xml()
 
     # Validate the XML.
-    with readable(rocoto_template) as f:
+    with open(rocoto_template, "r", encoding="utf-8") as f:
         schema = etree.RelaxNG(etree.parse(f))
     tree = etree.parse(input_xml)
     success = schema.validate(tree)

--- a/src/uwtools/rocoto.py
+++ b/src/uwtools/rocoto.py
@@ -2,6 +2,8 @@
 Support for creating Rocoto XML workflow documents.
 """
 
+from lxml import etree
+
 from uwtools.config.core import YAMLConfig
 from uwtools.config.j2template import J2Template
 
@@ -42,3 +44,18 @@ def write_rocoto_xml(input_yaml: str, input_template: str, rendered_output: str)
     # Render the template.
     template = J2Template(values=values.data, template_path=input_template)
     template.dump(output_path=rendered_output)
+
+
+def validate_rocoto_xml(input_xml: str, schema_file: str) -> bool:
+    """
+    Main entry point.
+
+    :param input_XML: Path to rendered XML file.
+    :param schema_file: Path to schema file.
+    """
+
+    # Validate the XML.
+    with open(schema_file, "r", encoding="utf-8") as f:
+        schema = etree.RelaxNG(etree.parse(f))
+    tree = etree.parse(input_xml)
+    return schema.validate(tree)

--- a/src/uwtools/rocoto.py
+++ b/src/uwtools/rocoto.py
@@ -68,7 +68,7 @@ def _rocoto_template() -> str:
 
 # Public functions
 def realize_rocoto_xml(
-    input_yaml: OptionalPath = None,
+    config_file: OptionalPath = None,
     rendered_output: OptionalPath = None,
 ) -> bool:
     """
@@ -82,12 +82,12 @@ def realize_rocoto_xml(
     rocoto_schema = _rocoto_schema()
 
     # Validate the YAML.
-    if uwtools.config.validator.validate_yaml(config_file=input_yaml, schema_file=rocoto_schema):
-        _add_tasks(input_yaml)
+    if uwtools.config.validator.validate_yaml(config_file=config_file, schema_file=rocoto_schema):
+        _add_tasks(config_file)
         # Render the template to a temporary file.
         with tempfile.NamedTemporaryFile(delete=False) as temp_file:
             write_rocoto_xml(
-                input_yaml=input_yaml,
+                config_file=config_file,
                 rendered_output=temp_file.name,
             )
             # Validate the XML.
@@ -97,7 +97,7 @@ def realize_rocoto_xml(
                 return True
         logging.error("Rocoto validation errors identified in %s", temp_file.name)
         return False
-    logging.error("YAML validation errors identified in %s", input_yaml)
+    logging.error("YAML validation errors identified in %s", config_file)
     return False
 
 
@@ -126,19 +126,19 @@ def validate_rocoto_xml(input_xml: OptionalPath = None) -> bool:
 
 
 def write_rocoto_xml(
-    input_yaml: OptionalPath = None,
+    config_file: OptionalPath = None,
     rendered_output: OptionalPath = None,
 ) -> None:
     """
     Render the given YAML file to XML using the given template.
 
-    :param input_yaml: Path to YAML input file.
+    :param config_file: Path to YAML input file.
     :param rendered_output: Path to write rendered XML file.
     """
 
     rocoto_template = _rocoto_template()
-    _add_tasks(input_yaml)
+    _add_tasks(config_file)
 
     # Render the template.
-    template = J2Template(values=YAMLConfig(input_yaml).data, template_path=str(rocoto_template))
+    template = J2Template(values=YAMLConfig(config_file).data, template_path=str(rocoto_template))
     template.dump(output_path=str(rendered_output))

--- a/src/uwtools/rocoto.py
+++ b/src/uwtools/rocoto.py
@@ -11,6 +11,7 @@ import uwtools.config.validator
 from uwtools.config.core import YAMLConfig
 from uwtools.config.j2template import J2Template
 from uwtools.types import OptionalPath
+from uwtools.utils.file import readable
 
 # Private functions
 
@@ -109,7 +110,7 @@ def validate_rocoto_xml(input_xml: OptionalPath = None, schema_file: OptionalPat
     """
 
     # Validate the XML.
-    with open(str(schema_file), "r", encoding="utf-8") as f:
+    with readable(schema_file) as f:
         schema = etree.RelaxNG(etree.parse(f))
     tree = etree.parse(input_xml)
     success = schema.validate(tree)

--- a/src/uwtools/rocoto.py
+++ b/src/uwtools/rocoto.py
@@ -36,7 +36,7 @@ def realize_rocoto_xml(
     input_template: str,
     rendered_output: str,
     schema_file: str,
-) -> None: #pragma: no cover
+) -> None:  # pragma: no cover
     """
     Main entry point.
 

--- a/src/uwtools/rocoto.py
+++ b/src/uwtools/rocoto.py
@@ -51,7 +51,7 @@ def _add_tasks(
 
 def _rocoto_schema_xml() -> DefinitePath:
     """
-    The path to the file containing the Rocoto workflow document template to render.
+    The path to the file containing the schema to validate the XML file against.
     """
     with resources.as_file(resources.files("uwtools.resources")) as path:
         return path / "schema_with_metatasks.rng"
@@ -59,10 +59,18 @@ def _rocoto_schema_xml() -> DefinitePath:
 
 def _rocoto_schema_yaml() -> DefinitePath:
     """
-    The path to the file containing the schema to validate the XML file against.
+    The path to the file containing the schema to validate the YAML file against.
     """
     with resources.as_file(resources.files("uwtools.resources")) as path:
         return path / "rocoto.jsonschema"
+
+
+def _rocoto_template_xml() -> DefinitePath:
+    """
+    The path to the file containing the Rocoto workflow document template to render.
+    """
+    with resources.as_file(resources.files("uwtools.resources")) as path:
+        return path / "rocoto.jinja2"
 
 
 def _write_rocoto_xml(
@@ -79,7 +87,7 @@ def _write_rocoto_xml(
     _add_tasks(config_file)
 
     # Render the template.
-    template = J2Template(values=YAMLConfig(config_file).data, template_path=_rocoto_schema_xml())
+    template = J2Template(values=YAMLConfig(config_file).data, template_path=_rocoto_template_xml())
     template.dump(output_path=str(rendered_output))
 
 

--- a/src/uwtools/rocoto.py
+++ b/src/uwtools/rocoto.py
@@ -42,55 +42,9 @@ def _add_tasks(
     :param input_yaml: Path to YAML input file.
     """
     values = YAMLConfig(input_yaml)
-    tasks = values["tasks"]
+    tasks = values["workflow"]["tasks"]
     if isinstance(tasks, dict):
         _add_jobname(tasks)
-
-
-# Public functions
-def realize_rocoto_xml(
-    input_yaml: OptionalPath = None,
-    rendered_output: OptionalPath = None,
-) -> bool:  # pragma: no cover
-    """
-    Realize the given YAML file to XML, using fixed Rocoto RelaxNG schema templates. Validate both
-    the YAML and the XML. External functions should call this function.
-
-    :param input_yaml: Path to YAML input file.
-    :param input_template: Path to input template file.
-    :param rendered_output: Path to write rendered XML file.
-    :param schema_file: Path to schema file.
-    """
-
-    _add_tasks(input_yaml)
-
-    rocoto_schema = _rocoto_schema()
-    rocoto_template = _rocoto_template()
-
-    # Validate the YAML.
-    if uwtools.config.validator.validate_yaml(config_file=input_yaml, schema_file=rocoto_schema):
-        # Render the template.
-        write_rocoto_xml(
-            input_yaml=input_yaml,
-            input_template=rocoto_template,
-            rendered_output=rendered_output,
-        )
-        # Validate the XML.
-        if validate_rocoto_xml(input_xml=rendered_output, schema_file=rocoto_template):
-            # If no issues were detected, report success.
-            return True
-        logging.error("Rocoto validation errors identified in %s", rendered_output)
-        return False
-    logging.error("YAML validation errors identified in %s", input_yaml)
-    return False
-
-
-def _rocoto_template() -> str:
-    """
-    The path to the file containing the template to validate the config file against.
-    """
-    with resources.as_file(resources.files("uwtools.resources")) as path:
-        return (path / "rocoto.jinja2").as_posix()
 
 
 def _rocoto_schema() -> str:
@@ -101,45 +55,88 @@ def _rocoto_schema() -> str:
         return (path / "rocoto.jsonschema").as_posix()
 
 
-def validate_rocoto_xml(input_xml: OptionalPath = None, schema_file: OptionalPath = None) -> bool:
+def _rocoto_template() -> str:
+    """
+    The path to the file containing the Rocoto workflow document template to render.
+    """
+    with resources.as_file(resources.files("uwtools.resources")) as path:
+        # return (path / "rocoto.jinja2").as_posix()
+        return (path / "schema_with_metatasks.rng").as_posix()
+
+
+# Public functions
+def realize_rocoto_xml(
+    input_yaml: OptionalPath = None,
+    rendered_output: OptionalPath = None,
+) -> bool:
+    """
+    Realize the given YAML file to XML, using the Rocoto RelaxNG schema. 
+    Validate both the YAML and the XML.
+
+    :param input_yaml: Path to YAML input file.
+    :param rendered_output: Path to write rendered XML file.
+    """
+
+    rocoto_schema = _rocoto_schema()
+
+    # Validate the YAML.
+    if uwtools.config.validator.validate_yaml(config_file=input_yaml, schema_file=rocoto_schema):
+        _add_tasks(input_yaml)
+        # Render the template.
+        write_rocoto_xml(
+            input_yaml=input_yaml,
+            rendered_output=rendered_output,
+        )
+        # Validate the XML.
+        if validate_rocoto_xml(input_xml=rendered_output):
+            # If no issues were detected, report success.
+            return True
+        logging.error(
+            "Rocoto validation errors identified in %s", rendered_output
+        )  # pragma: no cover
+        return False  # pragma: no cover
+    logging.error("YAML validation errors identified in %s", input_yaml)
+    return False
+
+
+def validate_rocoto_xml(input_xml: OptionalPath = None) -> bool:
     """
     Given a rendered XML file, validate it against the Rocoto schema.
 
     :param input_XML: Path to rendered XML file.
-    :param schema_file: Path to schema file.
     """
+    rocoto_template = _rocoto_template()
 
     # Validate the XML.
-    with readable(schema_file) as f:
+    with readable(rocoto_template) as f:
         schema = etree.RelaxNG(etree.parse(f))
     tree = etree.parse(input_xml)
     success = schema.validate(tree)
 
     # Store validation errors in the main log.
     errors = str(etree.RelaxNG.error_log).split("\n")
-    log_method = logging.debug if len(errors) else logging.info
+    log_method = logging.error if len(errors) else logging.info
     log_method("%s Rocoto validation error%s found", len(errors), "" if len(errors) == 1 else "s")
     for line in errors:
-        logging.debug(line)
+        logging.error(line)
 
     return success
 
 
 def write_rocoto_xml(
     input_yaml: OptionalPath = None,
-    input_template: OptionalPath = None,
     rendered_output: OptionalPath = None,
 ) -> None:
     """
-    Main entry point. Render the given YAML file to XML using the given template.
+    Render the given YAML file to XML using the given template.
 
     :param input_yaml: Path to YAML input file.
-    :param input_template: Path to input template file.
     :param rendered_output: Path to write rendered XML file.
     """
 
+    rocoto_template = _rocoto_template()
     _add_tasks(input_yaml)
 
     # Render the template.
-    template = J2Template(values=YAMLConfig(input_yaml).data, template_path=str(input_template))
+    template = J2Template(values=YAMLConfig(input_yaml).data, template_path=str(rocoto_template))
     template.dump(output_path=str(rendered_output))

--- a/src/uwtools/rocoto.py
+++ b/src/uwtools/rocoto.py
@@ -103,13 +103,13 @@ def realize_rocoto_xml(
 
     :param config_file: Path to YAML input file.
     :param rendered_output: Path to write rendered XML file.
+    :return: Did the input and output files conform to theirr schemas?
     """
 
     # Validate the YAML.
     if uwtools.config.validator.validate_yaml(
         config_file=config_file, schema_file=_rocoto_schema_yaml()
     ):
-        _add_jobname_to_tasks(config_file)
         # Render the template to a temporary file.
         with tempfile.NamedTemporaryFile(delete=False) as temp_file:
             _write_rocoto_xml(
@@ -132,6 +132,7 @@ def validate_rocoto_xml(input_xml: OptionalPath) -> bool:
     Given a rendered XML file, validate it against the Rocoto schema.
 
     :param input_xml: Path to rendered XML file.
+    :return: Did the XML file conform to the schema?
     """
 
     # Validate the XML.

--- a/src/uwtools/rocoto.py
+++ b/src/uwtools/rocoto.py
@@ -35,9 +35,9 @@ def _add_jobname(tree: dict) -> None:
             _add_jobname(subtree)
 
 
-def _add_tasks(
+def _add_jobname_to_tasks(
     input_yaml: OptionalPath = None,
-) -> None:
+) -> YAMLConfig:
     """
     Load YAML config and add job names to each defined workflow task.
 
@@ -47,6 +47,7 @@ def _add_tasks(
     tasks = values["workflow"]["tasks"]
     if isinstance(tasks, dict):
         _add_jobname(tasks)
+    return values
 
 
 def _rocoto_schema_xml() -> DefinitePath:
@@ -84,10 +85,10 @@ def _write_rocoto_xml(
     :param rendered_output: Path to write rendered XML file.
     """
 
-    _add_tasks(config_file)
+    values = _add_jobname_to_tasks(config_file)
 
     # Render the template.
-    template = J2Template(values=YAMLConfig(config_file).data, template_path=_rocoto_template_xml())
+    template = J2Template(values=values.data, template_path=_rocoto_template_xml())
     template.dump(output_path=str(rendered_output))
 
 
@@ -108,7 +109,7 @@ def realize_rocoto_xml(
     if uwtools.config.validator.validate_yaml(
         config_file=config_file, schema_file=_rocoto_schema_yaml()
     ):
-        _add_tasks(config_file)
+        _add_jobname_to_tasks(config_file)
         # Render the template to a temporary file.
         with tempfile.NamedTemporaryFile(delete=False) as temp_file:
             _write_rocoto_xml(

--- a/src/uwtools/rocoto.py
+++ b/src/uwtools/rocoto.py
@@ -101,7 +101,7 @@ def realize_rocoto_xml(
     Realize the Rocoto workflow defined in the given YAML as XML. Validate both the YAML input and
     XML output.
 
-    :param input_yaml: Path to YAML input file.
+    :param config_file: Path to YAML input file.
     :param rendered_output: Path to write rendered XML file.
     """
 

--- a/src/uwtools/rocoto.py
+++ b/src/uwtools/rocoto.py
@@ -65,7 +65,6 @@ def _rocoto_template() -> str:
         return (path / "schema_with_metatasks.rng").as_posix()
 
 
-
 def _write_rocoto_xml(
     config_file: OptionalPath = None,
     rendered_output: OptionalPath = None,
@@ -142,4 +141,3 @@ def validate_rocoto_xml(input_xml: OptionalPath = None) -> bool:
         logging.error(line)
 
     return success
-

--- a/src/uwtools/tests/config/test_j2template.py
+++ b/src/uwtools/tests/config/test_j2template.py
@@ -32,7 +32,7 @@ def test_bad_args(testdata):
 
 
 def test_dump(testdata, tmp_path):
-    path = str(tmp_path / "rendered.txt")
+    path = tmp_path / "rendered.txt"
     j2template = J2Template(testdata.config, template_str=testdata.template)
     j2template.dump(output_path=path)
     with open(path, "r", encoding="utf-8") as f:
@@ -43,7 +43,7 @@ def test_render_file(testdata, tmp_path):
     path = tmp_path / "template.jinja2"
     with path.open("w", encoding="utf-8") as f:
         print(testdata.template, file=f)
-    validate(J2Template(testdata.config, template_path=str(path)))
+    validate(J2Template(testdata.config, template_path=path))
 
 
 def test_render_string(testdata):

--- a/src/uwtools/tests/fixtures/hello_workflow.yaml
+++ b/src/uwtools/tests/fixtures/hello_workflow.yaml
@@ -1,3 +1,4 @@
+workflow:
   attrs:
     realtime: false
     scheduler: slurm

--- a/src/uwtools/tests/test_cli.py
+++ b/src/uwtools/tests/test_cli.py
@@ -292,7 +292,7 @@ def test__dispatch_forecast_run():
 @pytest.mark.parametrize(
     "params",
     [
-        (STR.write, "_dispatch_rocoto_write"),
+        (STR.realize, "_dispatch_rocoto_realize"),
         (STR.validate, "_dispatch_rocoto_validate"),
     ],
 )
@@ -305,74 +305,70 @@ def test__dispatch_rocoto(params):
     assert m.called_once_with(args)
 
 
-def test__dispatch_rocoto_write():
+def test__dispatch_rocoto_realize():
     args = ns()
     vars(args).update(
         {
             STR.infile: 1,
             STR.infmt: FORMAT.yaml,
-            STR.schemafile: 3,
-            STR.outfile: 4,
-            STR.outfmt: FORMAT.jinja2,
+            STR.outfile: 3,
+            STR.outfmt: FORMAT.rocoto,
         }
     )
     with patch.object(cli.uwtools.rocoto, "write_rocoto_xml") as m:
         with patch.object(cli.uwtools.config.validator, "validate_yaml", return_value=True):
             with patch.object(cli.uwtools.rocoto, "validate_rocoto_xml", return_value=True):
-                cli._dispatch_rocoto_write(args)
+                cli._dispatch_rocoto_realize(args)
     assert m.called_once_with(args)
 
 
-def test__dispatch_rocoto_write_invalid_input():
+def test__dispatch_rocoto_realize_invalid_input():
     args = ns()
     vars(args).update(
         {
             STR.infile: 1,
             STR.infmt: FORMAT.yaml,
-            STR.schemafile: 3,
-            STR.outfile: 4,
-            STR.outfmt: FORMAT.jinja2,
+            STR.outfile: 3,
+            STR.outfmt: FORMAT.rocoto,
         }
     )
     with patch.object(cli.uwtools.config.validator, "validate_yaml", return_value=False):
         with patch.object(cli.uwtools.rocoto, "validate_rocoto_xml", return_value=True):
-            assert cli._dispatch_rocoto_write(args) is False
+            assert cli._dispatch_rocoto_realize(args) is False
 
 
-def test__dispatch_rocoto_write_invalid_output():
+def test__dispatch_rocoto_realize_invalid_output():
     args = ns()
     vars(args).update(
         {
             STR.infile: 1,
             STR.infmt: FORMAT.yaml,
-            STR.schemafile: 3,
-            STR.outfile: 4,
-            STR.outfmt: FORMAT.jinja2,
+            STR.outfile: 3,
+            STR.outfmt: FORMAT.rocoto,
         }
     )
     with patch.object(cli.uwtools.rocoto, "write_rocoto_xml", create=True):
         with patch.object(cli.uwtools.config.validator, "validate_yaml", return_value=True):
             with patch.object(cli.uwtools.rocoto, "validate_rocoto_xml", return_value=False):
-                assert cli._dispatch_rocoto_write(args) is False
+                assert cli._dispatch_rocoto_realize(args) is False
 
 
-def test__dispatch_rocoto_write_unsupported():
+def test__dispatch_rocoto_realize_unsupported():
     args = ns()
     vars(args).update(
         {
             STR.infile: 1,
             STR.infmt: "jpg",
-            STR.schemafile: 3,
-            STR.outfile: 4,
+            STR.outfile: 3,
             STR.outfmt: "png",
         }
     )
-    assert cli._dispatch_rocoto_write(args) is False
+    assert cli._dispatch_rocoto_realize(args) is False
 
 
 def test__dispatch_rocoto_validate_xml():
     args = ns()
-    vars(args).update({STR.infile: 1, STR.infmt: FORMAT.jinja2, STR.schemafile: 3})
+    vars(args).update({STR.infile: 1, STR.infmt: FORMAT.rocoto})
     with patch.object(cli.uwtools.rocoto, "validate_rocoto_xml") as m:
         cli._dispatch_rocoto_validate(args)
     assert m.called_once_with(args)
@@ -380,7 +376,7 @@ def test__dispatch_rocoto_validate_xml():
 
 def test__dispatch_rocoto_validate_unsupported():
     args = ns()
-    vars(args).update({STR.infile: 1, STR.infmt: "jpg", STR.schemafile: 3})
+    vars(args).update({STR.infile: 1, STR.infmt: "jpg"})
     assert cli._dispatch_rocoto_validate(args) is False
 
 

--- a/src/uwtools/tests/test_cli.py
+++ b/src/uwtools/tests/test_cli.py
@@ -307,63 +307,22 @@ def test__dispatch_rocoto(params):
 
 def test__dispatch_rocoto_realize():
     args = ns()
-    vars(args).update(
-        {
-            STR.infile: 1,
-            STR.infmt: FORMAT.yaml,
-            STR.outfile: 3,
-            STR.outfmt: FORMAT.rocoto,
-        }
-    )
-    with patch.object(cli.uwtools.rocoto, "write_rocoto_xml") as m:
-        with patch.object(cli.uwtools.config.validator, "validate_yaml", return_value=True):
-            with patch.object(cli.uwtools.rocoto, "validate_rocoto_xml", return_value=True):
-                cli._dispatch_rocoto_realize(args)
+    vars(args).update({STR.infile: 1, STR.outfile: 2})
+    with patch.object(cli.uwtools.rocoto, "realize_rocoto_xml") as m:
+        cli._dispatch_rocoto_realize(args)
     assert m.called_once_with(args)
 
 
-def test__dispatch_rocoto_realize_invalid_input():
+def test__dispatch_rocoto_realize_invalid():
     args = ns()
     vars(args).update(
         {
             STR.infile: 1,
-            STR.infmt: FORMAT.yaml,
-            STR.outfile: 3,
-            STR.outfmt: FORMAT.rocoto,
+            STR.outfile: 2,
         }
     )
-    with patch.object(cli.uwtools.config.validator, "validate_yaml", return_value=False):
-        with patch.object(cli.uwtools.rocoto, "validate_rocoto_xml", return_value=True):
-            assert cli._dispatch_rocoto_realize(args) is False
-
-
-def test__dispatch_rocoto_realize_invalid_output():
-    args = ns()
-    vars(args).update(
-        {
-            STR.infile: 1,
-            STR.infmt: FORMAT.yaml,
-            STR.outfile: 3,
-            STR.outfmt: FORMAT.rocoto,
-        }
-    )
-    with patch.object(cli.uwtools.rocoto, "write_rocoto_xml", create=True):
-        with patch.object(cli.uwtools.config.validator, "validate_yaml", return_value=True):
-            with patch.object(cli.uwtools.rocoto, "validate_rocoto_xml", return_value=False):
-                assert cli._dispatch_rocoto_realize(args) is False
-
-
-def test__dispatch_rocoto_realize_unsupported():
-    args = ns()
-    vars(args).update(
-        {
-            STR.infile: 1,
-            STR.infmt: "jpg",
-            STR.outfile: 3,
-            STR.outfmt: "png",
-        }
-    )
-    assert cli._dispatch_rocoto_realize(args) is False
+    with patch.object(cli.uwtools.rocoto, "realize_rocoto_xml", return_value=False):
+        assert cli._dispatch_rocoto_realize(args) is False
 
 
 def test__dispatch_rocoto_validate_xml():
@@ -374,10 +333,11 @@ def test__dispatch_rocoto_validate_xml():
     assert m.called_once_with(args)
 
 
-def test__dispatch_rocoto_validate_unsupported():
+def test__dispatch_rocoto_validate_xml_invalid():
     args = ns()
-    vars(args).update({STR.infile: 1, STR.infmt: "jpg", STR.verbose: False})
-    assert cli._dispatch_rocoto_validate(args) is False
+    vars(args).update({STR.infile: 1, STR.verbose: False})
+    with patch.object(cli.uwtools.rocoto, "validate_rocoto_xml", return_value=False):
+        assert cli._dispatch_rocoto_validate(args) is False
 
 
 @pytest.mark.parametrize("params", [(STR.render, "_dispatch_template_render")])

--- a/src/uwtools/tests/test_cli.py
+++ b/src/uwtools/tests/test_cli.py
@@ -192,17 +192,17 @@ def test__dispatch_config(params):
     submode, funcname = params
     args = ns()
     vars(args).update({STR.submode: submode})
-    with patch.object(cli, funcname) as m:
+    with patch.object(cli, funcname) as module:
         cli._dispatch_config(args)
-    assert m.called_once_with(args)
+    assert module.called_once_with(args)
 
 
 def test__dispatch_config_compare():
     args = ns()
     vars(args).update({STR.file1path: 1, STR.file1fmt: 2, STR.file2path: 3, STR.file2fmt: 4})
-    with patch.object(cli.uwtools.config.core, "compare_configs") as m:
+    with patch.object(cli.uwtools.config.core, "compare_configs") as module:
         cli._dispatch_config_compare(args)
-    assert m.called_once_with(args)
+    assert module.called_once_with(args)
 
 
 def test__dispatch_config_realize():
@@ -219,9 +219,9 @@ def test__dispatch_config_realize():
             STR.dryrun: 8,
         }
     )
-    with patch.object(cli.uwtools.config.core, "realize_config") as m:
+    with patch.object(cli.uwtools.config.core, "realize_config") as module:
         cli._dispatch_config_realize(args)
-    assert m.called_once_with(args)
+    assert module.called_once_with(args)
 
 
 def test__dispatch_config_translate_arparse_to_jinja2():
@@ -235,9 +235,9 @@ def test__dispatch_config_translate_arparse_to_jinja2():
             STR.dryrun: 5,
         }
     )
-    with patch.object(cli.uwtools.config.atparse_to_jinja2, "convert") as m:
+    with patch.object(cli.uwtools.config.atparse_to_jinja2, "convert") as module:
         cli._dispatch_config_translate(args)
-    assert m.called_once_with(args)
+    assert module.called_once_with(args)
 
 
 def test__dispatch_config_translate_unsupported():
@@ -251,9 +251,9 @@ def test__dispatch_config_translate_unsupported():
 def test__dispatch_config_validate_yaml():
     args = ns()
     vars(args).update({STR.infile: 1, STR.infmt: FORMAT.yaml, STR.schemafile: 3})
-    with patch.object(cli.uwtools.config.validator, "validate_yaml") as m:
+    with patch.object(cli.uwtools.config.validator, "validate_yaml") as module:
         cli._dispatch_config_validate(args)
-    assert m.called_once_with(args)
+    assert module.called_once_with(args)
 
 
 def test__dispatch_config_validate_unsupported():
@@ -267,9 +267,9 @@ def test__dispatch_forecast(params):
     submode, funcname = params
     args = ns()
     vars(args).update({STR.submode: submode})
-    with patch.object(cli, funcname) as m:
+    with patch.object(cli, funcname) as module:
         cli._dispatch_forecast(args)
-    assert m.called_once_with(args)
+    assert module.called_once_with(args)
 
 
 def test__dispatch_forecast_run():
@@ -281,12 +281,12 @@ def test__dispatch_forecast_run():
         forecast_model="foo",
     )
     vars(args).update({STR.cfgfile: 1, "forecast_model": "foo"})
-    with patch.object(cli.uwtools.drivers.forecast, "FooForecast", create=True) as m:
+    with patch.object(cli.uwtools.drivers.forecast, "FooForecast", create=True) as module:
         CLASSES = {"foo": getattr(cli.uwtools.drivers.forecast, "FooForecast")}
         with patch.object(cli.uwtools.drivers.forecast, "CLASSES", new=CLASSES):
             cli._dispatch_forecast_run(args)
-    assert m.called_once_with(args)
-    m().run.assert_called_once_with(cycle="2023-01-01T00:00:00")
+    assert module.called_once_with(args)
+    module().run.assert_called_once_with(cycle="2023-01-01T00:00:00")
 
 
 @pytest.mark.parametrize(
@@ -300,17 +300,17 @@ def test__dispatch_rocoto(params):
     submode, funcname = params
     args = ns()
     vars(args).update({STR.submode: submode})
-    with patch.object(cli, funcname) as m:
+    with patch.object(cli, funcname) as module:
         cli._dispatch_rocoto(args)
-    assert m.called_once_with(args)
+    assert module.called_once_with(args)
 
 
 def test__dispatch_rocoto_realize():
     args = ns()
     vars(args).update({STR.infile: 1, STR.outfile: 2})
-    with patch.object(cli.uwtools.rocoto, "realize_rocoto_xml") as m:
+    with patch.object(cli.uwtools.rocoto, "realize_rocoto_xml") as module:
         cli._dispatch_rocoto_realize(args)
-    assert m.called_once_with(args)
+    assert module.called_once_with(args)
 
 
 def test__dispatch_rocoto_realize_invalid():
@@ -328,9 +328,9 @@ def test__dispatch_rocoto_realize_invalid():
 def test__dispatch_rocoto_validate_xml():
     args = ns()
     vars(args).update({STR.infile: 1, STR.infmt: FORMAT.rocoto, STR.verbose: False})
-    with patch.object(cli.uwtools.rocoto, "validate_rocoto_xml") as m:
+    with patch.object(cli.uwtools.rocoto, "validate_rocoto_xml") as module:
         cli._dispatch_rocoto_validate(args)
-    assert m.called_once_with(args)
+    assert module.called_once_with(args)
 
 
 def test__dispatch_rocoto_validate_xml_invalid():
@@ -345,9 +345,9 @@ def test__dispatch_template(params):
     submode, funcname = params
     args = ns()
     vars(args).update({STR.submode: submode})
-    with patch.object(cli, funcname) as m:
+    with patch.object(cli, funcname) as module:
         cli._dispatch_template(args)
-    assert m.called_once_with(args)
+    assert module.called_once_with(args)
 
 
 def test__dispatch_template_render_yaml():
@@ -363,9 +363,9 @@ def test__dispatch_template_render_yaml():
             STR.dryrun: 7,
         }
     )
-    with patch.object(cli.uwtools.config.templater, STR.render) as m:
+    with patch.object(cli.uwtools.config.templater, STR.render) as module:
         cli._dispatch_template_render(args)
-    assert m.called_once_with(args)
+    assert module.called_once_with(args)
 
 
 @pytest.mark.parametrize("quiet", [True])

--- a/src/uwtools/tests/test_cli.py
+++ b/src/uwtools/tests/test_cli.py
@@ -327,7 +327,7 @@ def test__dispatch_rocoto_realize_invalid():
 
 def test__dispatch_rocoto_validate_xml():
     args = ns()
-    vars(args).update({STR.infile: 1, STR.infmt: FORMAT.rocoto, STR.verbose: False})
+    vars(args).update({STR.infile: 1})
     with patch.object(cli.uwtools.rocoto, "validate_rocoto_xml") as module:
         cli._dispatch_rocoto_validate(args)
     assert module.called_once_with(args)

--- a/src/uwtools/tests/test_cli.py
+++ b/src/uwtools/tests/test_cli.py
@@ -368,7 +368,7 @@ def test__dispatch_rocoto_realize_unsupported():
 
 def test__dispatch_rocoto_validate_xml():
     args = ns()
-    vars(args).update({STR.infile: 1, STR.infmt: FORMAT.rocoto})
+    vars(args).update({STR.infile: 1, STR.infmt: FORMAT.rocoto, STR.verbose: False})
     with patch.object(cli.uwtools.rocoto, "validate_rocoto_xml") as m:
         cli._dispatch_rocoto_validate(args)
     assert m.called_once_with(args)
@@ -376,7 +376,7 @@ def test__dispatch_rocoto_validate_xml():
 
 def test__dispatch_rocoto_validate_unsupported():
     args = ns()
-    vars(args).update({STR.infile: 1, STR.infmt: "jpg"})
+    vars(args).update({STR.infile: 1, STR.infmt: "jpg", STR.verbose: False})
     assert cli._dispatch_rocoto_validate(args) is False
 
 

--- a/src/uwtools/tests/test_cli.py
+++ b/src/uwtools/tests/test_cli.py
@@ -192,17 +192,17 @@ def test__dispatch_config(params):
     submode, funcname = params
     args = ns()
     vars(args).update({STR.submode: submode})
-    with patch.object(cli, funcname) as module:
+    with patch.object(cli, funcname) as func:
         cli._dispatch_config(args)
-    assert module.called_once_with(args)
+    assert func.called_once_with(args)
 
 
 def test__dispatch_config_compare():
     args = ns()
     vars(args).update({STR.file1path: 1, STR.file1fmt: 2, STR.file2path: 3, STR.file2fmt: 4})
-    with patch.object(cli.uwtools.config.core, "compare_configs") as module:
+    with patch.object(cli.uwtools.config.core, "compare_configs") as compare_configs:
         cli._dispatch_config_compare(args)
-    assert module.called_once_with(args)
+    assert compare_configs.called_once_with(args)
 
 
 def test__dispatch_config_realize():
@@ -219,9 +219,9 @@ def test__dispatch_config_realize():
             STR.dryrun: 8,
         }
     )
-    with patch.object(cli.uwtools.config.core, "realize_config") as module:
+    with patch.object(cli.uwtools.config.core, "realize_config") as realize_config:
         cli._dispatch_config_realize(args)
-    assert module.called_once_with(args)
+    assert realize_config.called_once_with(args)
 
 
 def test__dispatch_config_translate_arparse_to_jinja2():
@@ -235,9 +235,9 @@ def test__dispatch_config_translate_arparse_to_jinja2():
             STR.dryrun: 5,
         }
     )
-    with patch.object(cli.uwtools.config.atparse_to_jinja2, "convert") as module:
+    with patch.object(cli.uwtools.config.atparse_to_jinja2, "convert") as convert:
         cli._dispatch_config_translate(args)
-    assert module.called_once_with(args)
+    assert convert.called_once_with(args)
 
 
 def test__dispatch_config_translate_unsupported():
@@ -251,9 +251,9 @@ def test__dispatch_config_translate_unsupported():
 def test__dispatch_config_validate_yaml():
     args = ns()
     vars(args).update({STR.infile: 1, STR.infmt: FORMAT.yaml, STR.schemafile: 3})
-    with patch.object(cli.uwtools.config.validator, "validate_yaml") as module:
+    with patch.object(cli.uwtools.config.validator, "validate_yaml") as validate_yaml:
         cli._dispatch_config_validate(args)
-    assert module.called_once_with(args)
+    assert validate_yaml.called_once_with(args)
 
 
 def test__dispatch_config_validate_unsupported():
@@ -281,12 +281,12 @@ def test__dispatch_forecast_run():
         forecast_model="foo",
     )
     vars(args).update({STR.cfgfile: 1, "forecast_model": "foo"})
-    with patch.object(cli.uwtools.drivers.forecast, "FooForecast", create=True) as module:
+    with patch.object(cli.uwtools.drivers.forecast, "FooForecast", create=True) as FooForecast:
         CLASSES = {"foo": getattr(cli.uwtools.drivers.forecast, "FooForecast")}
         with patch.object(cli.uwtools.drivers.forecast, "CLASSES", new=CLASSES):
             cli._dispatch_forecast_run(args)
-    assert module.called_once_with(args)
-    module().run.assert_called_once_with(cycle="2023-01-01T00:00:00")
+    assert FooForecast.called_once_with(args)
+    FooForecast().run.assert_called_once_with(cycle="2023-01-01T00:00:00")
 
 
 @pytest.mark.parametrize(
@@ -328,9 +328,9 @@ def test__dispatch_rocoto_realize_invalid():
 def test__dispatch_rocoto_validate_xml():
     args = ns()
     vars(args).update({STR.infile: 1})
-    with patch.object(cli.uwtools.rocoto, "validate_rocoto_xml") as module:
+    with patch.object(cli.uwtools.rocoto, "validate_rocoto_xml") as validate:
         cli._dispatch_rocoto_validate(args)
-    assert module.called_once_with(args)
+    assert validate.called_once_with(args)
 
 
 def test__dispatch_rocoto_validate_xml_invalid():
@@ -345,9 +345,9 @@ def test__dispatch_template(params):
     submode, funcname = params
     args = ns()
     vars(args).update({STR.submode: submode})
-    with patch.object(cli, funcname) as module:
+    with patch.object(cli, funcname) as func:
         cli._dispatch_template(args)
-    assert module.called_once_with(args)
+    assert func.called_once_with(args)
 
 
 def test__dispatch_template_render_yaml():
@@ -363,9 +363,9 @@ def test__dispatch_template_render_yaml():
             STR.dryrun: 7,
         }
     )
-    with patch.object(cli.uwtools.config.templater, STR.render) as module:
+    with patch.object(cli.uwtools.config.templater, STR.render) as templater:
         cli._dispatch_template_render(args)
-    assert module.called_once_with(args)
+    assert templater.called_once_with(args)
 
 
 @pytest.mark.parametrize("quiet", [True])

--- a/src/uwtools/tests/test_cli.py
+++ b/src/uwtools/tests/test_cli.py
@@ -289,6 +289,52 @@ def test__dispatch_forecast_run():
     m().run.assert_called_once_with(cycle="2023-01-01T00:00:00")
 
 
+@pytest.mark.parametrize(
+    "params",
+    [
+        (STR.write, "_dispatch_rocoto_write"),
+        (STR.validate, "_dispatch_rocoto_validate"),
+    ],
+)
+def test__dispatch_rocoto(params):
+    submode, funcname = params
+    args = ns()
+    vars(args).update({STR.submode: submode})
+    with patch.object(cli, funcname) as m:
+        cli._dispatch_rocoto(args)
+    assert m.called_once_with(args)
+
+
+def test__dispatch_rocoto_write():
+    args = ns()
+    vars(args).update(
+        {
+            STR.infile: 1,
+            STR.infmt: 2,
+            STR.schemafile: 3,
+            STR.outfile: 4,
+            STR.outfmt: 5,
+        }
+    )
+    with patch.object(cli.uwtools.rocoto, "write_rocoto_xml") as m:
+        cli._dispatch_rocoto_write(args)
+    assert m.called_once_with(args)
+
+
+def test__dispatch_rocoto_validate_xml():
+    args = ns()
+    vars(args).update({STR.infile: 1, STR.infmt: FORMAT.xml, STR.schemafile: 3})
+    with patch.object(cli.uwtools.rocoto, "validate_rocoto_xml") as m:
+        cli._dispatch_rocoto_validate(args)
+    assert m.called_once_with(args)
+
+
+def test_dispath_rocoto_validate_unsupported():
+    args = ns()
+    vars(args).update({STR.infile: 1, STR.infmt: "jpg", STR.schemafile: 3})
+    assert cli._dispatch_rocoto_validate(args) is False
+
+
 @pytest.mark.parametrize("params", [(STR.render, "_dispatch_template_render")])
 def test__dispatch_template(params):
     submode, funcname = params

--- a/src/uwtools/tests/test_rocoto.py
+++ b/src/uwtools/tests/test_rocoto.py
@@ -43,6 +43,18 @@ metatask_howdy:
     assert expected == tree
 
 
+def test__rocoto_template():
+    with resources.as_file(resources.files("uwtools.resources")) as path:
+        expected = (path / "rocoto.jinja2").as_posix()
+    assert rocoto._rocoto_template() == expected
+
+
+def test__rocoto_schema():
+    with resources.as_file(resources.files("uwtools.resources")) as path:
+        expected = (path / "rocoto.jsonschema").as_posix()
+    assert rocoto._rocoto_schema() == expected
+
+
 def test_write_rocoto_xml(tmp_path):
     input_yaml = support.fixture_path("hello_workflow.yaml")
     with resources.as_file(resources.files("uwtools.resources")) as resc:
@@ -62,6 +74,6 @@ def test_rocoto_xml_is_valid(vals):
     with resources.as_file(resources.files("uwtools.resources")) as resc:
         xml = support.fixture_path(fn)
         schema = resc / "schema_with_metatasks.rng"
-    result = rocoto.validate_rocoto_xml(input_xml=xml, schema_file=str(schema))
+    result = rocoto.validate_rocoto_xml(input_xml=xml, schema_file=schema)
 
     assert result is validity

--- a/src/uwtools/tests/test_rocoto.py
+++ b/src/uwtools/tests/test_rocoto.py
@@ -105,10 +105,8 @@ def test_rocoto_xml_is_valid(vals):
 def test__write_rocoto_xml(tmp_path):
     config_file = support.fixture_path("hello_workflow.yaml")
     output = tmp_path / "rendered.xml"
-    config = YAMLConfig(config_file)
 
-    with patch.object(rocoto, "_add_jobname_to_tasks", return_value=config):
-        rocoto._write_rocoto_xml(config_file=config_file, rendered_output=output)
+    rocoto._write_rocoto_xml(config_file=config_file, rendered_output=output)
 
     expected = support.fixture_path("hello_workflow.xml")
     assert support.compare_files(expected, output) is True

--- a/src/uwtools/tests/test_rocoto.py
+++ b/src/uwtools/tests/test_rocoto.py
@@ -98,12 +98,12 @@ def test_rocoto_xml_is_valid(vals):
     assert result is validity
 
 
-def test_write_rocoto_xml(tmp_path):
+def test__write_rocoto_xml(tmp_path):
     input_yaml = support.fixture_path("hello_workflow.yaml")
     output = tmp_path / "rendered.xml"
 
     with patch.object(rocoto, "_add_tasks", return_value=None):
-        rocoto.write_rocoto_xml(input_yaml=input_yaml, rendered_output=output)
+        rocoto._write_rocoto_xml(input_yaml=input_yaml, rendered_output=output)
 
     expected = support.fixture_path("hello_workflow.xml")
     support.compare_files(expected, output)

--- a/src/uwtools/tests/test_rocoto.py
+++ b/src/uwtools/tests/test_rocoto.py
@@ -76,16 +76,16 @@ def test_realize_rocoto_xml(vals, tmp_path):
     with patch.object(rocoto, "validate_rocoto_xml", value=True):
         with patch.object(rocoto.uwtools.config.validator, "_bad_paths", return_value=None):
             with resources.as_file(resources.files("uwtools.tests.fixtures")) as path:
-                input_yaml = (path / fn).as_posix()
-                result = rocoto.realize_rocoto_xml(input_yaml=input_yaml, rendered_output=output)
+                config_file = (path / fn).as_posix()
+                result = rocoto.realize_rocoto_xml(config_file=config_file, rendered_output=output)
     assert result is validity
 
 
 def test_realize_rocoto_invalid_xml():
-    input_yaml = support.fixture_path("hello_workflow.yaml")
+    config_file = support.fixture_path("hello_workflow.yaml")
     output = support.fixture_path("rocoto_invalid.xml")
-    with patch.object(rocoto, "write_rocoto_xml", return_value=None):
-        result = rocoto.realize_rocoto_xml(input_yaml=input_yaml, rendered_output=output)
+    with patch.object(rocoto, "_write_rocoto_xml", return_value=None):
+        result = rocoto.realize_rocoto_xml(config_file=config_file, rendered_output=output)
     assert result is False
 
 
@@ -99,11 +99,11 @@ def test_rocoto_xml_is_valid(vals):
 
 
 def test__write_rocoto_xml(tmp_path):
-    input_yaml = support.fixture_path("hello_workflow.yaml")
+    config_file = support.fixture_path("hello_workflow.yaml")
     output = tmp_path / "rendered.xml"
 
     with patch.object(rocoto, "_add_tasks", return_value=None):
-        rocoto._write_rocoto_xml(input_yaml=input_yaml, rendered_output=output)
+        rocoto._write_rocoto_xml(config_file=config_file, rendered_output=output)
 
     expected = support.fixture_path("hello_workflow.xml")
     support.compare_files(expected, output)

--- a/src/uwtools/tests/test_rocoto.py
+++ b/src/uwtools/tests/test_rocoto.py
@@ -61,7 +61,7 @@ def test_write_rocoto_xml(tmp_path):
         input_template = resc / "rocoto.jinja2"
     output = tmp_path / "rendered.xml"
     rocoto.write_rocoto_xml(
-        input_yaml=input_yaml, input_template=str(input_template), rendered_output=str(output)
+        input_yaml=input_yaml, input_template=input_template, rendered_output=output
     )
 
     expected = support.fixture_path("hello_workflow.xml")

--- a/src/uwtools/tests/test_rocoto.py
+++ b/src/uwtools/tests/test_rocoto.py
@@ -111,4 +111,4 @@ def test__write_rocoto_xml(tmp_path):
         rocoto._write_rocoto_xml(config_file=config_file, rendered_output=output)
 
     expected = support.fixture_path("hello_workflow.xml")
-    support.compare_files(expected, output)
+    assert support.compare_files(expected, output) is True

--- a/src/uwtools/tests/test_rocoto.py
+++ b/src/uwtools/tests/test_rocoto.py
@@ -4,17 +4,19 @@ Tests for uwtools.rocoto module.
 """
 
 from importlib import resources
+from unittest.mock import patch
 
 import pytest
 import yaml
 
 from uwtools import rocoto
+from uwtools.config.core import YAMLConfig
 from uwtools.tests import support
 
 # Test functions
 
 
-def test_add_jobname():
+def test__add_jobname():
     expected = yaml.safe_load(
         """
 task_hello:
@@ -43,9 +45,20 @@ metatask_howdy:
     assert expected == tree
 
 
+def test__add_tasks():
+    with resources.as_file(resources.files("uwtools.tests.fixtures")) as path:
+        input_yaml = (path / "hello_workflow.yaml").as_posix()
+
+    values = YAMLConfig(input_yaml)
+    tasks = values["workflow"]["tasks"]
+    with patch.object(rocoto, "_add_jobname") as module:
+        rocoto._add_tasks(input_yaml)
+    assert module.called_once_with(tasks)
+
+
 def test__rocoto_template():
     with resources.as_file(resources.files("uwtools.resources")) as path:
-        expected = (path / "rocoto.jinja2").as_posix()
+        expected = (path / "schema_with_metatasks.rng").as_posix()
     assert rocoto._rocoto_template() == expected
 
 
@@ -55,25 +68,42 @@ def test__rocoto_schema():
     assert rocoto._rocoto_schema() == expected
 
 
-def test_write_rocoto_xml(tmp_path):
-    input_yaml = support.fixture_path("hello_workflow.yaml")
-    with resources.as_file(resources.files("uwtools.resources")) as resc:
-        input_template = resc / "rocoto.jinja2"
+@pytest.mark.parametrize("vals", [("hello_workflow.yaml", True), ("fruit_config.yaml", False)])
+def test_realize_rocoto_xml(vals, tmp_path):
+    fn, validity = vals
     output = tmp_path / "rendered.xml"
-    rocoto.write_rocoto_xml(
-        input_yaml=input_yaml, input_template=input_template, rendered_output=output
-    )
 
-    expected = support.fixture_path("hello_workflow.xml")
-    support.compare_files(expected, output)
+    with patch.object(rocoto, "validate_rocoto_xml", value=True):
+        with patch.object(rocoto.uwtools.config.validator, "_bad_paths", return_value=None):
+            with resources.as_file(resources.files("uwtools.tests.fixtures")) as path:
+                input_yaml = (path / fn).as_posix()
+                result = rocoto.realize_rocoto_xml(input_yaml=input_yaml, rendered_output=output)
+    assert result is validity
+
+
+def test_realize_rocoto_invalid_xml():
+    input_yaml = support.fixture_path("hello_workflow.yaml")
+    output = support.fixture_path("rocoto_invalid.xml")
+    with patch.object(rocoto, "write_rocoto_xml", return_value=None):
+        result = rocoto.realize_rocoto_xml(input_yaml=input_yaml, rendered_output=output)
+    assert result is False
 
 
 @pytest.mark.parametrize("vals", [("hello_workflow.xml", True), ("rocoto_invalid.xml", False)])
 def test_rocoto_xml_is_valid(vals):
     fn, validity = vals
-    with resources.as_file(resources.files("uwtools.resources")) as resc:
-        xml = support.fixture_path(fn)
-        schema = resc / "schema_with_metatasks.rng"
-    result = rocoto.validate_rocoto_xml(input_xml=xml, schema_file=schema)
+    xml = support.fixture_path(fn)
+    result = rocoto.validate_rocoto_xml(input_xml=xml)
 
     assert result is validity
+
+
+def test_write_rocoto_xml(tmp_path):
+    input_yaml = support.fixture_path("hello_workflow.yaml")
+    output = tmp_path / "rendered.xml"
+
+    with patch.object(rocoto, "_add_tasks", return_value=None):
+        rocoto.write_rocoto_xml(input_yaml=input_yaml, rendered_output=output)
+
+    expected = support.fixture_path("hello_workflow.xml")
+    support.compare_files(expected, output)

--- a/src/uwtools/tests/test_rocoto.py
+++ b/src/uwtools/tests/test_rocoto.py
@@ -56,16 +56,16 @@ def test__add_tasks():
     assert module.called_once_with(tasks)
 
 
-def test__rocoto_template():
-    with resources.as_file(resources.files("uwtools.resources")) as path:
-        expected = (path / "schema_with_metatasks.rng").as_posix()
-    assert rocoto._rocoto_template() == expected
-
-
-def test__rocoto_schema():
+def test__rocoto_schema_yaml():
     with resources.as_file(resources.files("uwtools.resources")) as path:
         expected = (path / "rocoto.jsonschema").as_posix()
-    assert rocoto._rocoto_schema() == expected
+    assert rocoto._rocoto_schema_yaml() == expected
+
+
+def test__rocoto_schema_xml():
+    with resources.as_file(resources.files("uwtools.resources")) as path:
+        expected = (path / "schema_with_metatasks.rng").as_posix()
+    assert rocoto._rocoto_schema_xml() == expected
 
 
 @pytest.mark.parametrize("vals", [("hello_workflow.yaml", True), ("fruit_config.yaml", False)])
@@ -84,7 +84,7 @@ def test_realize_rocoto_xml(vals, tmp_path):
 def test_realize_rocoto_invalid_xml():
     config_file = support.fixture_path("hello_workflow.yaml")
     output = support.fixture_path("rocoto_invalid.xml")
-    with patch.object(rocoto, "_write_rocoto_xml", return_value=None):
+    with patch.object(rocoto.uwtools.config.validator, "_bad_paths", return_value=None):
         result = rocoto.realize_rocoto_xml(config_file=config_file, rendered_output=output)
     assert result is False
 

--- a/src/uwtools/tests/test_rocoto.py
+++ b/src/uwtools/tests/test_rocoto.py
@@ -7,7 +7,6 @@ from importlib import resources
 
 import pytest
 import yaml
-from lxml import etree
 
 from uwtools import rocoto
 from uwtools.tests import support
@@ -61,9 +60,8 @@ def test_write_rocoto_xml(tmp_path):
 def test_rocoto_xml_is_valid(vals):
     fn, validity = vals
     with resources.as_file(resources.files("uwtools.resources")) as resc:
-        with open(resc / "schema_with_metatasks.rng", "r", encoding="utf-8") as f:
-            schema = etree.RelaxNG(etree.parse(f))
+        xml = support.fixture_path(fn)
+        schema = resc / "schema_with_metatasks.rng"
+    result = rocoto.validate_rocoto_xml(input_xml=xml, schema_file=str(schema))
 
-    xml = support.fixture_path(fn)
-    tree = etree.parse(xml)
-    assert schema.validate(tree) is validity
+    assert result is validity

--- a/src/uwtools/tests/test_rocoto.py
+++ b/src/uwtools/tests/test_rocoto.py
@@ -3,6 +3,7 @@
 Tests for uwtools.rocoto module.
 """
 
+import tempfile
 from importlib import resources
 from unittest.mock import patch
 
@@ -86,7 +87,8 @@ def test_realize_rocoto_invalid_xml():
     xml = support.fixture_path("rocoto_invalid.xml")
     with patch.object(rocoto, "_write_rocoto_xml", return_value=None):
         with patch.object(rocoto.uwtools.config.validator, "_bad_paths", return_value=None):
-            with patch.object(rocoto.tempfile, "NamedTemporaryFile", return_value=xml):
+            with patch.object(tempfile, "NamedTemporaryFile") as context_manager:
+                context_manager.return_value.__enter__.return_value.name = xml
                 result = rocoto.realize_rocoto_xml(config_file=config_file, rendered_output=xml)
     assert result is False
 

--- a/src/uwtools/tests/test_rocoto.py
+++ b/src/uwtools/tests/test_rocoto.py
@@ -47,7 +47,7 @@ metatask_howdy:
 
 def test__add_tasks():
     with resources.as_file(resources.files("uwtools.tests.fixtures")) as path:
-        input_yaml = (path / "hello_workflow.yaml").as_posix()
+        input_yaml = path / "hello_workflow.yaml"
 
     values = YAMLConfig(input_yaml)
     tasks = values["workflow"]["tasks"]
@@ -58,13 +58,13 @@ def test__add_tasks():
 
 def test__rocoto_schema_yaml():
     with resources.as_file(resources.files("uwtools.resources")) as path:
-        expected = (path / "rocoto.jsonschema").as_posix()
+        expected = path / "rocoto.jsonschema"
     assert rocoto._rocoto_schema_yaml() == expected
 
 
 def test__rocoto_schema_xml():
     with resources.as_file(resources.files("uwtools.resources")) as path:
-        expected = (path / "schema_with_metatasks.rng").as_posix()
+        expected = path / "schema_with_metatasks.rng"
     assert rocoto._rocoto_schema_xml() == expected
 
 
@@ -76,7 +76,7 @@ def test_realize_rocoto_xml(vals, tmp_path):
     with patch.object(rocoto, "validate_rocoto_xml", value=True):
         with patch.object(rocoto.uwtools.config.validator, "_bad_paths", return_value=None):
             with resources.as_file(resources.files("uwtools.tests.fixtures")) as path:
-                config_file = (path / fn).as_posix()
+                config_file = path / fn
                 result = rocoto.realize_rocoto_xml(config_file=config_file, rendered_output=output)
     assert result is validity
 

--- a/src/uwtools/utils/file.py
+++ b/src/uwtools/utils/file.py
@@ -40,9 +40,7 @@ class _FORMAT:
     ini: str = _ini
     jinja2: str = _jinja2
     nml: str = _nml
-    rocoto: str = _xml
     sh: str = _ini
-    xml: str = _xml
     yaml: str = _yaml
     yml: str = _yaml
 

--- a/src/uwtools/utils/file.py
+++ b/src/uwtools/utils/file.py
@@ -28,6 +28,7 @@ class _FORMAT:
     _ini: str = "ini"
     _jinja2: str = "jinja2"
     _nml: str = "nml"
+    _xml: str = "xml"
     _yaml: str = "yaml"
 
     # Variants:
@@ -39,7 +40,9 @@ class _FORMAT:
     ini: str = _ini
     jinja2: str = _jinja2
     nml: str = _nml
+    rocoto: str = _xml
     sh: str = _ini
+    xml: str = _xml
     yaml: str = _yaml
     yml: str = _yaml
 

--- a/src/uwtools/utils/file.py
+++ b/src/uwtools/utils/file.py
@@ -28,6 +28,7 @@ class _FORMAT:
     _ini: str = "ini"
     _jinja2: str = "jinja2"
     _nml: str = "nml"
+    _rocoto: str = "rocoto"
     _yaml: str = "yaml"
 
     # Variants:
@@ -39,7 +40,9 @@ class _FORMAT:
     ini: str = _ini
     jinja2: str = _jinja2
     nml: str = _nml
+    rocoto: str = _rocoto
     sh: str = _ini
+    xml: str = _rocoto
     yaml: str = _yaml
     yml: str = _yaml
 

--- a/src/uwtools/utils/file.py
+++ b/src/uwtools/utils/file.py
@@ -28,7 +28,6 @@ class _FORMAT:
     _ini: str = "ini"
     _jinja2: str = "jinja2"
     _nml: str = "nml"
-    _rocoto: str = "rocoto"
     _yaml: str = "yaml"
 
     # Variants:
@@ -40,9 +39,7 @@ class _FORMAT:
     ini: str = _ini
     jinja2: str = _jinja2
     nml: str = _nml
-    rocoto: str = _rocoto
     sh: str = _ini
-    xml: str = _rocoto
     yaml: str = _yaml
     yml: str = _yaml
 


### PR DESCRIPTION
**Description**
Add the Rocoto XML tool to the modal CLI, including both XML generation and validation. Generation must validate both input and output. Include appropriate tests at all steps.

Due to UW-334 requiring validation, both 322 and 334 will be completed together.
Completes issues #316 and #315 

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [x] pytests in GitHub actions.
- [ ] Tests on Ubunbu OS


**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes need updates to the documentation.  I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [x] Any dependent changes have been merged and published

