### PR TITLE
switchable-logging

### DIFF
--- a/src/uwtools/apps/srw.py
+++ b/src/uwtools/apps/srw.py
@@ -2,11 +2,11 @@
 This file contains the specific drivers for a particular app, using the facade pattern base class.
 """
 
-import logging
 import shutil
 
 from uwtools.drivers.facade import Facade
 from uwtools.exceptions import UWError
+from uwtools.logging import log
 from uwtools.utils.file import FORMAT, get_file_type
 from uwtools.utils.processing import execute
 
@@ -47,7 +47,7 @@ class SRW210(Facade):
             shutil.copy2(config_file, "config.yaml")
         else:
             msg = f"Bad file type -- {file_type}. Cannot load configuration!"
-            logging.critical(msg)
+            log.critical(msg)
             raise ValueError(msg)
 
     def validate_config(self, config_file: str) -> None:

--- a/src/uwtools/cli.py
+++ b/src/uwtools/cli.py
@@ -3,7 +3,6 @@ Modal CLI.
 """
 
 import datetime
-import logging
 import sys
 from argparse import ArgumentParser as Parser
 from argparse import HelpFormatter, Namespace
@@ -19,7 +18,7 @@ import uwtools.config.core
 import uwtools.config.templater
 import uwtools.config.validator
 import uwtools.drivers.forecast
-from uwtools.logging import setup_logging
+from uwtools.logging import log, setup_logging
 from uwtools.utils.file import FORMAT, get_file_type
 
 FORMATS = [FORMAT.ini, FORMAT.nml, FORMAT.yaml]
@@ -45,7 +44,7 @@ def main() -> None:
         for check in checks[args.mode][args.submode]:
             check(args)
         setup_logging(quiet=args.quiet, verbose=args.verbose)
-        logging.debug("Command: %s %s", Path(sys.argv[0]).name, " ".join(sys.argv[1:]))
+        log.debug("Command: %s %s", Path(sys.argv[0]).name, " ".join(sys.argv[1:]))
         modes = {
             STR.config: _dispatch_config,
             STR.forecast: _dispatch_forecast,

--- a/src/uwtools/cli.py
+++ b/src/uwtools/cli.py
@@ -18,8 +18,8 @@ import uwtools.config.core
 import uwtools.config.templater
 import uwtools.config.validator
 import uwtools.drivers.forecast
-from uwtools.logging import log, setup_logging
 import uwtools.rocoto
+from uwtools.logging import log, setup_logging
 from uwtools.utils.file import FORMAT, get_file_type
 
 FORMATS = [FORMAT.ini, FORMAT.nml, FORMAT.yaml]

--- a/src/uwtools/config/atparse_to_jinja2.py
+++ b/src/uwtools/config/atparse_to_jinja2.py
@@ -2,10 +2,10 @@
 Utilities for rendering Jinja2 templates.
 """
 
-import logging
 import re
 from typing import IO, Any, Generator, Optional
 
+from uwtools.logging import log
 from uwtools.utils.file import readable, writable
 
 
@@ -34,7 +34,7 @@ def convert(
 
     if dry_run:
         for line in lines():
-            logging.info(line)
+            log.info(line)
     else:
         with writable(output_file) as f:
             write(f)

--- a/src/uwtools/config/j2template.py
+++ b/src/uwtools/config/j2template.py
@@ -2,12 +2,12 @@
 Support for handling Jinja2 templates.
 """
 
-import logging
 import os
 from typing import List, Optional, Set
 
 from jinja2 import BaseLoader, Environment, FileSystemLoader, Template, meta
 
+from uwtools.logging import log
 from uwtools.types import DefinitePath, OptionalPath
 from uwtools.utils.file import readable
 
@@ -50,7 +50,7 @@ class J2Template:
         :param output_path: Path to file to write.
         """
         msg = f"Writing rendered template to output file: {output_path}"
-        logging.debug(msg)
+        log.debug(msg)
         with open(output_path, "w+", encoding="utf-8") as f:
             print(self.render(), file=f)
 

--- a/src/uwtools/config/templater.py
+++ b/src/uwtools/config/templater.py
@@ -2,13 +2,12 @@
 Support for rendering Jinja2 templates.
 """
 
-import logging
 import os
 from typing import Dict, Optional
 
 from uwtools.config.core import format_to_config
 from uwtools.config.j2template import J2Template
-from uwtools.logging import MSGWIDTH
+from uwtools.logging import MSGWIDTH, log
 from uwtools.types import DefinitePath, OptionalPath
 from uwtools.utils.file import get_file_type, readable, writable
 
@@ -45,9 +44,9 @@ def render(
     # then return.
 
     if values_needed:
-        logging.info("Value(s) needed to render this template are:")
+        log.info("Value(s) needed to render this template are:")
         for var in sorted(undeclared_variables):
-            logging.info(var)
+            log.info(var)
         return True
 
     # Check for missing values required to render the template. If found, report them and raise an
@@ -56,9 +55,9 @@ def render(
     missing = [var for var in undeclared_variables if var not in values.keys()]
     if missing:
         msg = "Required value(s) not provided:"
-        logging.error(msg)
+        log.error(msg)
         for key in missing:
-            logging.error(key)
+            log.error(key)
         return False
 
     # In dry-run mode, display the rendered template and then return.
@@ -66,7 +65,7 @@ def render(
     if dry_run:
         rendered_template = template.render()
         for line in rendered_template.split("\n"):
-            logging.info(line)
+            log.info(line)
         return True
 
     # Write rendered template to file.
@@ -82,11 +81,11 @@ def _report(args: dict) -> None:
 
     :param args: The argument names and their values.
     """
-    dashes = lambda: logging.debug("-" * MSGWIDTH)
-    logging.debug("Internal arguments:")
+    dashes = lambda: log.debug("-" * MSGWIDTH)
+    log.debug("Internal arguments:")
     dashes()
     for varname, value in args.items():
-        logging.debug("%16s: %s", varname, value)
+        log.debug("%16s: %s", varname, value)
     dashes()
 
 
@@ -108,11 +107,11 @@ def _set_up_values_obj(
             values_format = get_file_type(values_file)
         values_class = format_to_config(values_format)
         values = values_class(values_file).data
-        logging.debug("Read initial values from %s", values_file)
+        log.debug("Read initial values from %s", values_file)
     else:
         values = dict(os.environ)  # Do not modify os.environ: Make a copy.
-        logging.debug("Initial values taken from environment")
+        log.debug("Initial values taken from environment")
     if overrides:
         values.update(overrides)
-        logging.debug("Updated values with overrides: %s", " ".join(overrides))
+        log.debug("Updated values with overrides: %s", " ".join(overrides))
     return values

--- a/src/uwtools/config/validator.py
+++ b/src/uwtools/config/validator.py
@@ -3,13 +3,13 @@ Support for validating a config using JSON Schema.
 """
 
 import json
-import logging
 from pathlib import Path
 from typing import List, Optional
 
 import jsonschema
 
 from uwtools.config.core import YAMLConfig
+from uwtools.logging import log
 from uwtools.types import DefinitePath, OptionalPath
 
 # Public functions
@@ -34,11 +34,11 @@ def validate_yaml(
         schema = json.load(f)
     # Collect and report on schema-validation errors.
     errors = _validation_errors(yaml_config.data, schema)
-    log_method = logging.error if errors else logging.info
+    log_method = log.error if errors else log.info
     log_method("%s schema-validation error%s found", len(errors), "" if len(errors) == 1 else "s")
     for error in errors:
         for line in str(error).split("\n"):
-            logging.error(line)
+            log.error(line)
     # It's pointless to evaluate an invalid config, so return now if that's the case.
     if errors:
         return False
@@ -46,7 +46,7 @@ def validate_yaml(
     if check_paths:
         if bad_paths := _bad_paths(yaml_config.data, schema):
             for bad_path in bad_paths:
-                logging.error("Path does not exist: %s", bad_path)
+                log.error("Path does not exist: %s", bad_path)
             return False
     # If no issues were detected, report success.
     return True

--- a/src/uwtools/drivers/driver.py
+++ b/src/uwtools/drivers/driver.py
@@ -2,7 +2,6 @@
 Provides an abstract class representing drivers for various NWP tools.
 """
 
-import logging
 import os
 import shutil
 from abc import ABC, abstractmethod
@@ -12,6 +11,7 @@ from typing import Any, Dict, Optional, Type, Union
 
 from uwtools.config import validator
 from uwtools.config.core import Config, YAMLConfig
+from uwtools.logging import log
 from uwtools.scheduler import BatchScript, JobScheduler
 from uwtools.types import OptionalPath
 
@@ -130,7 +130,7 @@ class Driver(ABC):
             else:
                 link_or_copy(src_path_or_paths, dst_path)  # type: ignore
                 msg = f"File {src_path_or_paths} staged as {dst_path}"
-                logging.info(msg)
+                log.info(msg)
 
     # Private methods
 
@@ -160,7 +160,7 @@ class Driver(ABC):
             config_class.dump_dict(path=output_path, cfg=user_values)
 
         msg = f"Configure file {output_path} created"
-        logging.info(msg)
+        log.info(msg)
 
     def _validate(self) -> bool:
         """

--- a/src/uwtools/drivers/forecast.py
+++ b/src/uwtools/drivers/forecast.py
@@ -3,7 +3,6 @@ Drivers for forecast models.
 """
 
 
-import logging
 import os
 import sys
 from collections.abc import Mapping
@@ -14,6 +13,7 @@ from typing import Dict, Optional
 
 from uwtools.config.core import FieldTableConfig, NMLConfig, YAMLConfig
 from uwtools.drivers.driver import Driver
+from uwtools.logging import log
 from uwtools.scheduler import BatchScript
 from uwtools.types import DefinitePath, OptionalPath
 from uwtools.utils.file import handle_existing
@@ -72,7 +72,7 @@ class FV3Forecast(Driver):
         # Exit program with error if caller chooses to quit.
 
         if exist_act == "quit" and os.path.isdir(run_directory):
-            logging.critical("User chose quit option when creating directory")
+            log.critical("User chose quit option when creating directory")
             sys.exit(1)
 
         # Delete or rename directory if it exists.
@@ -83,7 +83,7 @@ class FV3Forecast(Driver):
 
         for subdir in ("INPUT", "RESTART"):
             path = os.path.join(run_directory, subdir)
-            logging.info("Creating directory: %s", path)
+            log.info("Creating directory: %s", path)
             os.makedirs(path)
 
     def create_field_table(self, output_path: OptionalPath) -> None:
@@ -170,7 +170,7 @@ class FV3Forecast(Driver):
             if self._dry_run:
                 # Apply switch to allow user to view the run command of config.
                 # This will not run the job.
-                logging.info("Batch Script:")
+                log.info("Batch Script:")
                 batch_script.dump(None)
                 return True
 
@@ -180,7 +180,7 @@ class FV3Forecast(Driver):
         pre_run = self._mpi_env_variables(" ")
         full_cmd = f"{pre_run} {self.run_cmd()}"
         if self._dry_run:
-            logging.info("Would run: ")
+            log.info("Would run: ")
             print(full_cmd, file=sys.stdout)
             return True
 

--- a/src/uwtools/files/gateway/s3.py
+++ b/src/uwtools/files/gateway/s3.py
@@ -2,13 +2,14 @@
 Gateway for interacting with S3.
 """
 
-import logging
 import os
 import pathlib
 from typing import Optional
 
 import boto3
 from botocore.exceptions import ClientError
+
+from uwtools.logging import log
 
 S3_CLIENT = boto3.client("s3")
 
@@ -46,6 +47,6 @@ def upload_file(source_path: str, bucket: str, target_name: Optional[str] = None
     try:
         S3_CLIENT.upload_file(source_path, bucket, target_name)
     except ClientError as error:
-        logging.error(error)
+        log.error(error)
         return False
     return True

--- a/src/uwtools/files/gateway/unix.py
+++ b/src/uwtools/files/gateway/unix.py
@@ -2,13 +2,13 @@
 Unix-based, threaded, local file copying.
 """
 
-import logging
 import shutil
 from concurrent.futures import ThreadPoolExecutor, wait
 from pathlib import Path
 from typing import List, Tuple
 
 from uwtools.files.model import File
+from uwtools.logging import log
 
 
 class Copier:
@@ -41,7 +41,7 @@ def _copy(src: Path, dst: Path) -> None:
 
     Directories are copied recursively.
     """
-    logging.debug("Copying %s to %s", src, dst)
+    log.debug("Copying %s to %s", src, dst)
     if src.is_file():
         shutil.copy(src, dst)
     else:

--- a/src/uwtools/logging.py
+++ b/src/uwtools/logging.py
@@ -23,7 +23,7 @@ class _Logger:
     """
 
     def __init__(self) -> None:
-        self.logger = logging.getLogger()  # default to Python base logger.
+        self.logger = logging.getLogger()  # default to Python root logger.
 
     def __getattr__(self, attr: str) -> Any:
         """

--- a/src/uwtools/logging.py
+++ b/src/uwtools/logging.py
@@ -5,6 +5,7 @@ Logging support.
 import logging
 import os
 import sys
+from typing import Any
 
 # The logging prefix
 #
@@ -15,7 +16,26 @@ import sys
 
 MSGWIDTH = 69
 
-log = logging.getLogger()  # default to Python base logger
+
+class _Logger:
+    """
+    Support for swappable loggers.
+    """
+
+    def __init__(self) -> None:
+        self.logger = logging.getLogger()  # default to Python base logger.
+
+    def __getattr__(self, attr: str) -> Any:
+        """
+        Delegate attribute access to the currently-used logger.
+
+        :param attr: The attribute to access.
+        :returns: The requested attribute.
+        """
+        return getattr(self.logger, attr)
+
+
+log = _Logger()
 
 
 def setup_logging(quiet: bool = False, verbose: bool = False) -> None:
@@ -46,5 +66,4 @@ def use_logger(logger: logging.Logger) -> None:
 
     :param logger: The logger to log to.
     """
-    global log  # pylint: disable=global-statement
-    log = logger
+    log.logger = logger

--- a/src/uwtools/logging.py
+++ b/src/uwtools/logging.py
@@ -15,6 +15,8 @@ import sys
 
 MSGWIDTH = 69
 
+log = logging.getLogger()  # default to Python base logger
+
 
 def setup_logging(quiet: bool = False, verbose: bool = False) -> None:
     """
@@ -36,3 +38,13 @@ def setup_logging(quiet: bool = False, verbose: bool = False) -> None:
         **({"filename": os.devnull} if quiet else {}),
     }
     logging.basicConfig(**kwargs)
+
+
+def use_logger(logger: logging.Logger) -> None:
+    """
+    Log hereafter via the given logger.
+
+    :param logger: The logger to log to.
+    """
+    global log  # pylint: disable=global-statement
+    log = logger

--- a/src/uwtools/rocoto.py
+++ b/src/uwtools/rocoto.py
@@ -2,7 +2,6 @@
 Support for creating Rocoto XML workflow documents.
 """
 
-import logging
 import shutil
 import tempfile
 from importlib import resources
@@ -12,6 +11,7 @@ from lxml import etree
 import uwtools.config.validator
 from uwtools.config.core import YAMLConfig
 from uwtools.config.j2template import J2Template
+from uwtools.logging import log
 from uwtools.types import DefinitePath, OptionalPath
 from uwtools.utils.file import readable
 
@@ -121,9 +121,9 @@ def realize_rocoto_xml(
                 # If no issues were detected, save temp file and report success.
                 shutil.move(temp_file.name, rendered_output)
                 return True
-        logging.error("Rocoto validation errors identified in %s", temp_file.name)
+        log.error("Rocoto validation errors identified in %s", temp_file.name)
         return False
-    logging.error("YAML validation errors identified in %s", config_file)
+    log.error("YAML validation errors identified in %s", config_file)
     return False
 
 
@@ -145,9 +145,9 @@ def validate_rocoto_xml(input_xml: OptionalPath) -> bool:
 
     # Log validation errors.
     errors = str(etree.RelaxNG.error_log).split("\n")
-    log_method = logging.error if len(errors) else logging.info
+    log_method = log.error if len(errors) else log.info
     log_method("%s Rocoto validation error%s found", len(errors), "" if len(errors) == 1 else "s")
     for line in errors:
-        logging.error(line)
+        log.error(line)
 
     return success

--- a/src/uwtools/scheduler.py
+++ b/src/uwtools/scheduler.py
@@ -4,12 +4,12 @@ Job Scheduling.
 
 from __future__ import annotations
 
-import logging
 import re
 from collections import UserDict, UserList
 from collections.abc import Mapping
 from typing import Any, Dict, List
 
+from uwtools.logging import log
 from uwtools.types import DefinitePath, OptionalPath
 from uwtools.utils import Memory
 from uwtools.utils.file import writable
@@ -179,7 +179,7 @@ class JobScheduler(UserDict):
         if "scheduler" not in props:
             raise KeyError(f"No scheduler defined in props: [{', '.join(props.keys())}]")
         name = props["scheduler"]
-        logging.debug("Getting '%s' scheduler", name)
+        log.debug("Getting '%s' scheduler", name)
         schedulers = {"slurm": Slurm, "pbs": PBS, "lsf": LSF}
         try:
             scheduler = schedulers[name]

--- a/src/uwtools/tests/config/test_atparse_to_jinja2.py
+++ b/src/uwtools/tests/config/test_atparse_to_jinja2.py
@@ -11,6 +11,7 @@ from unittest.mock import patch
 from pytest import fixture
 
 from uwtools.config import atparse_to_jinja2
+from uwtools.logging import log
 
 # Helper functions
 
@@ -48,7 +49,7 @@ def test_convert_input_file_to_output_file(atparsefile, capsys, jinja2txt, tmp_p
 
 
 def test_convert_input_file_to_logging(atparsefile, caplog, capsys, jinja2txt, tmp_path):
-    logging.getLogger().setLevel(logging.INFO)
+    log.setLevel(logging.INFO)
     outfile = tmp_path / "outfile"
     atparse_to_jinja2.convert(input_file=atparsefile, dry_run=True)
     streams = capsys.readouterr()
@@ -76,7 +77,7 @@ def test_convert_stdin_to_file(atparselines, capsys, jinja2txt, tmp_path):
 
 
 def test_convert_stdin_to_logging(atparselines, caplog, jinja2txt, tmp_path):
-    logging.getLogger().setLevel(logging.INFO)
+    log.setLevel(logging.INFO)
     outfile = tmp_path / "outfile"
     with patch.object(sys, "stdin", new=StringIO("\n".join(atparselines))):
         atparse_to_jinja2.convert(output_file=outfile, dry_run=True)

--- a/src/uwtools/tests/config/test_core.py
+++ b/src/uwtools/tests/config/test_core.py
@@ -20,6 +20,7 @@ from pytest import fixture, raises
 from uwtools import exceptions
 from uwtools.config import core
 from uwtools.exceptions import UWConfigError
+from uwtools.logging import log
 from uwtools.tests.support import compare_files, fixture_path, logged
 from uwtools.utils.file import FORMAT, path_if_it_exists, writable
 
@@ -31,7 +32,7 @@ def test_compare_config(caplog, fmt, salad_base):
     """
     Compare two config objects.
     """
-    logging.getLogger().setLevel(logging.INFO)
+    log.setLevel(logging.INFO)
     cfgobj = core.format_to_config(fmt)(fixture_path(f"simple.{fmt}"))
     if fmt == FORMAT.ini:
         salad_base["salad"]["how_many"] = "12"  # str "12" (not int 12) for ini
@@ -55,7 +56,7 @@ def test_compare_config(caplog, fmt, salad_base):
 
 
 def test_compare_configs_good(compare_configs_assets, caplog):
-    logging.getLogger().setLevel(logging.INFO)
+    log.setLevel(logging.INFO)
     _, a, b = compare_configs_assets
     assert core.compare_configs(
         config_a_path=a, config_a_format=FORMAT.yaml, config_b_path=b, config_b_format=FORMAT.yaml
@@ -64,7 +65,7 @@ def test_compare_configs_good(compare_configs_assets, caplog):
 
 
 def test_compare_configs_changed_value(compare_configs_assets, caplog):
-    logging.getLogger().setLevel(logging.INFO)
+    log.setLevel(logging.INFO)
     d, a, b = compare_configs_assets
     d["baz"]["qux"] = 11
     with writable(b) as f:
@@ -76,7 +77,7 @@ def test_compare_configs_changed_value(compare_configs_assets, caplog):
 
 
 def test_compare_configs_missing_key(compare_configs_assets, caplog):
-    logging.getLogger().setLevel(logging.INFO)
+    log.setLevel(logging.INFO)
     d, a, b = compare_configs_assets
     del d["baz"]
     with writable(b) as f:
@@ -89,7 +90,7 @@ def test_compare_configs_missing_key(compare_configs_assets, caplog):
 
 
 def test_compare_configs_bad_format(caplog):
-    logging.getLogger().setLevel(logging.INFO)
+    log.setLevel(logging.INFO)
     with raises(UWConfigError) as e:
         core.compare_configs(
             config_a_path="/not/used",
@@ -187,7 +188,7 @@ def test_dereference_exceptions(caplog, tmp_path):
     """
     Test that dereference handles some standard mistakes.
     """
-    logging.getLogger().setLevel(logging.DEBUG)
+    log.setLevel(logging.DEBUG)
     path = tmp_path / "cfg.yaml"
     with open(path, "w", encoding="utf-8") as f:
         print(
@@ -204,7 +205,7 @@ type_prob: '{{ list_a / \"a\" }}'  # TypeError
         )
     cfgobj = core.YAMLConfig(config_file=path)
     cfgobj.dereference()
-    logging.info("HELLO")
+    log.info("HELLO")
     raised = [record.message for record in caplog.records if "raised" in record.message]
     assert "ZeroDivisionError" in raised[0]
     assert "TypeError" in raised[1]
@@ -425,7 +426,7 @@ def test_realize_config_dry_run(caplog):
     """
     Test that providing a YAML base file with a dry-run flag will print an YAML config file.
     """
-    logging.getLogger().setLevel(logging.INFO)
+    log.setLevel(logging.INFO)
     infile = fixture_path("fruit_config.yaml")
     yaml_config = core.YAMLConfig(infile)
     yaml_config.dereference_all()
@@ -615,7 +616,7 @@ def test__realize_config_update(realize_config_testobj, tmp_path):
 
 
 def test__realize_config_values_needed(caplog, tmp_path):
-    logging.getLogger().setLevel(logging.INFO)
+    log.setLevel(logging.INFO)
     path = tmp_path / "a.yaml"
     with writable(path) as f:
         yaml.dump({1: "complete", 2: "{{ jinja2 }}", 3: ""}, f)
@@ -650,7 +651,7 @@ def test_values_needed_ini(caplog):
     Test that the values_needed flag logs keys completed, keys containing unfilled Jinja2 templates,
     and keys set to empty.
     """
-    logging.getLogger().setLevel(logging.INFO)
+    log.setLevel(logging.INFO)
     core.realize_config(
         input_file=fixture_path("simple3.ini"),
         input_format=FORMAT.ini,
@@ -689,7 +690,7 @@ def test_values_needed_nml(caplog):
     Test that the values_needed flag logs keys completed, keys containing unfilled Jinja2 templates,
     and keys set to empty.
     """
-    logging.getLogger().setLevel(logging.INFO)
+    log.setLevel(logging.INFO)
     core.realize_config(
         input_file=fixture_path("simple3.nml"),
         input_format=FORMAT.nml,
@@ -725,7 +726,7 @@ def test_values_needed_yaml(caplog):
     Test that the values_needed flag logs keys completed, keys containing unfilled Jinja2 templates,
     and keys set to empty.
     """
-    logging.getLogger().setLevel(logging.INFO)
+    log.setLevel(logging.INFO)
     core.realize_config(
         input_file=fixture_path("srw_example.yaml"),
         input_format=FORMAT.yaml,
@@ -915,7 +916,7 @@ def test_YAMLConfig__load_paths_failure_stdin_plus_relpath(caplog):
     # provide YAML with an include directive specifying a relative path. Since a relative path
     # is meaningless relative to stdin, assert that an appropriate error is logged and exception
     # raised.
-    logging.getLogger().setLevel(logging.INFO)
+    log.setLevel(logging.INFO)
     relpath = "../bar/baz.yaml"
     with patch.object(core.sys, "stdin", new=StringIO(f"foo: {core.INCLUDE_TAG} [{relpath}]")):
         with raises(UWConfigError) as e:

--- a/src/uwtools/tests/config/test_templater.py
+++ b/src/uwtools/tests/config/test_templater.py
@@ -11,6 +11,7 @@ import yaml
 from pytest import fixture
 
 from uwtools.config import templater
+from uwtools.logging import log
 from uwtools.tests.support import logged
 
 
@@ -52,7 +53,7 @@ def test_render(values_file, template, tmp_path):
 
 
 def test_render_dry_run(caplog, values_file, template):
-    logging.getLogger().setLevel(logging.INFO)
+    log.setLevel(logging.INFO)
     render_helper(
         input_file=template, values_file=values_file, output_file="/dev/null", dry_run=True
     )
@@ -61,7 +62,7 @@ def test_render_dry_run(caplog, values_file, template):
 
 def test_render_values_missing(caplog, values_file, template):
     # Read in the config, remove the "roses" key, then re-write it.
-    logging.getLogger().setLevel(logging.INFO)
+    log.setLevel(logging.INFO)
     with open(values_file, "r", encoding="utf-8") as f:
         cfgobj = yaml.safe_load(f.read())
     del cfgobj["roses"]
@@ -73,7 +74,7 @@ def test_render_values_missing(caplog, values_file, template):
 
 
 def test_render_values_needed(caplog, values_file, template):
-    logging.getLogger().setLevel(logging.INFO)
+    log.setLevel(logging.INFO)
     render_helper(
         input_file=template, values_file=values_file, output_file="/dev/null", values_needed=True
     )
@@ -82,7 +83,7 @@ def test_render_values_needed(caplog, values_file, template):
 
 
 def test__report(caplog):
-    logging.getLogger().setLevel(logging.DEBUG)
+    log.setLevel(logging.DEBUG)
     expected = """
 Internal arguments:
 ---------------------------------------------------------------------

--- a/src/uwtools/tests/config/test_validator.py
+++ b/src/uwtools/tests/config/test_validator.py
@@ -12,6 +12,7 @@ from unittest.mock import patch
 from pytest import fixture
 
 from uwtools.config import validator
+from uwtools.logging import log
 from uwtools.tests.support import logged, regex_logged
 
 # Support functions
@@ -77,7 +78,7 @@ def write_as_json(data: Dict[str, Any], path: Path) -> Path:
 
 def test_validate_yaml_fail_bad_dir_top(caplog, config, config_file, schema, schema_file, tmp_path):
     # Specify a non-existent directory for the topmost directory value.
-    logging.getLogger().setLevel(logging.INFO)
+    log.setLevel(logging.INFO)
     d = str(tmp_path / "no-such-dir")
     config["dir"] = d
     write_as_json(config, config_file)
@@ -90,7 +91,7 @@ def test_validate_yaml_fail_bad_dir_nested(
     caplog, config, config_file, schema, schema_file, tmp_path
 ):
     # Specify a non-existent directory for the nested directory value.
-    logging.getLogger().setLevel(logging.INFO)
+    log.setLevel(logging.INFO)
     d = str(tmp_path / "no-such-dir")
     config["sub"]["dir"] = d
     write_as_json(config, config_file)
@@ -101,7 +102,7 @@ def test_validate_yaml_fail_bad_dir_nested(
 
 def test_validate_yaml_fail_bad_enum_val(caplog, config, config_file, schema, schema_file):
     # Specify an invalid enum value.
-    logging.getLogger().setLevel(logging.INFO)
+    log.setLevel(logging.INFO)
     config["color"] = "yellow"
     write_as_json(config, config_file)
     write_as_json(schema, schema_file)
@@ -112,7 +113,7 @@ def test_validate_yaml_fail_bad_enum_val(caplog, config, config_file, schema, sc
 
 def test_validate_yaml_fail_bad_number_val(caplog, config, config_file, schema, schema_file):
     # Specify an invalid number value.
-    logging.getLogger().setLevel(logging.INFO)
+    log.setLevel(logging.INFO)
     config["number"] = "string"
     write_as_json(config, config_file)
     write_as_json(schema, schema_file)

--- a/src/uwtools/tests/drivers/test_driver.py
+++ b/src/uwtools/tests/drivers/test_driver.py
@@ -12,6 +12,7 @@ import pytest
 from pytest import fixture
 
 from uwtools.drivers.driver import Driver
+from uwtools.logging import log
 from uwtools.tests.support import logged
 
 
@@ -92,7 +93,7 @@ def test_validation(caplog, configs, schema, tmp_path, valid):
     with open(schema_file, "w", encoding="utf-8") as f:
         print(schema, file=f)
     with patch.object(ConcreteDriver, "schema_file", new=schema_file):
-        logging.getLogger().setLevel(logging.INFO)
+        log.setLevel(logging.INFO)
         ConcreteDriver(config_file=config_file)
         if valid:
             assert logged(caplog, "0 schema-validation errors found")

--- a/src/uwtools/tests/drivers/test_forecast.py
+++ b/src/uwtools/tests/drivers/test_forecast.py
@@ -16,6 +16,7 @@ from uwtools.config.core import NMLConfig, YAMLConfig
 from uwtools.drivers import forecast
 from uwtools.drivers.driver import Driver
 from uwtools.drivers.forecast import FV3Forecast
+from uwtools.logging import log
 from uwtools.tests.support import compare_files, fixture_path
 
 
@@ -332,7 +333,7 @@ def test_run_direct(fv3_mpi_assets, fv3_run_assets):
 
 @pytest.mark.parametrize("with_batch_script", [True, False])
 def test_FV3Forecast_run_dry_run(capsys, fv3_mpi_assets, fv3_run_assets, with_batch_script):
-    logging.getLogger().setLevel(logging.INFO)
+    log.setLevel(logging.INFO)
     batch_script, config_file, config = fv3_run_assets
     if with_batch_script:
         batch_components = [

--- a/src/uwtools/tests/test_cli.py
+++ b/src/uwtools/tests/test_cli.py
@@ -13,6 +13,7 @@ from pytest import fixture, raises
 
 from uwtools import cli
 from uwtools.cli import STR
+from uwtools.logging import log
 from uwtools.utils.file import FORMAT
 
 # Test functions
@@ -126,7 +127,7 @@ def test__check_file_vs_format_pass_implicit(fmt):
 
 
 def test__check_quiet_vs_verbose_fail(capsys):
-    logging.getLogger().setLevel(logging.INFO)
+    log.setLevel(logging.INFO)
     args = ns()
     vars(args).update({STR.quiet: True, STR.verbose: True})
     with raises(SystemExit):

--- a/src/uwtools/tests/test_logging.py
+++ b/src/uwtools/tests/test_logging.py
@@ -1,4 +1,4 @@
-# pylint: disable=missing-function-docstring
+# pylint: disable=missing-function-docstring,protected-access
 """
 Tests for uwtools.logging module.
 """
@@ -50,3 +50,13 @@ def test_setup_logging_verbose():
             format=ANY,
             level=logging.DEBUG,
         )
+
+
+def test_use_logger():
+    with patch.object(uwtools.logging, "log", uwtools.logging._Logger()):
+        # Initially, uwtools logging uses the Python root logger:
+        assert uwtools.logging.log.logger == logging.getLogger()
+        # But the logger can be swapped to use a logger of choice:
+        test_logger = logging.getLogger("test-logger")
+        uwtools.logging.use_logger(test_logger)
+        assert uwtools.logging.log.logger == test_logger

--- a/src/uwtools/tests/utils/test_processing.py
+++ b/src/uwtools/tests/utils/test_processing.py
@@ -3,12 +3,14 @@
 Tests for uwtools.utils.processing module.
 """
 
+import logging
+
 from uwtools.tests.support import logged
 from uwtools.utils import processing
 
 
 def test_run_failure(caplog):
-    processing.logging.getLogger().setLevel(processing.logging.INFO)
+    processing.log.setLevel(logging.INFO)
     cmd = "expr 1 / 0"
     result = processing.execute(cmd=cmd)
     assert "division by zero" in result.output
@@ -20,9 +22,9 @@ def test_run_failure(caplog):
 
 
 def test_run_success(caplog, tmp_path):
-    processing.logging.getLogger().setLevel(processing.logging.INFO)
+    processing.log.setLevel(logging.INFO)
     cmd = "echo hello $FOO"
-    assert processing.execute(cmd=cmd, cwd=tmp_path, env={"FOO": "bar"}, log=True)
+    assert processing.execute(cmd=cmd, cwd=tmp_path, env={"FOO": "bar"}, log_output=True)
     assert logged(caplog, "Executing: %s" % cmd)
     assert logged(caplog, "  in %s" % tmp_path)
     assert logged(caplog, "  with environment variables:")

--- a/src/uwtools/utils/file.py
+++ b/src/uwtools/utils/file.py
@@ -2,7 +2,6 @@
 Helpers for working with files and directories.
 """
 
-import logging
 import os
 import shutil
 import sys
@@ -12,6 +11,7 @@ from datetime import datetime as dt
 from pathlib import Path
 from typing import IO, Generator
 
+from uwtools.logging import log
 from uwtools.types import DefinitePath, OptionalPath
 
 
@@ -60,7 +60,7 @@ def get_file_type(path: DefinitePath) -> str:
     if fmt := vars(FORMAT).get(suffix):
         return fmt
     msg = f"Cannot deduce format of '{path}' from unknown extension '{suffix}'"
-    logging.critical(msg)
+    log.critical(msg)
     raise ValueError(msg)
 
 
@@ -79,7 +79,7 @@ def handle_existing(directory: str, action: str) -> None:
             shutil.rmtree(directory)
     except (FileExistsError, RuntimeError) as e:
         msg = f"Could not delete directory {directory}"
-        logging.critical(msg)
+        log.critical(msg)
         raise RuntimeError(msg) from e
 
     # Try to rename existing run directory if option is rename.
@@ -91,7 +91,7 @@ def handle_existing(directory: str, action: str) -> None:
             shutil.move(directory, save_dir)
     except (FileExistsError, RuntimeError) as e:
         msg = f"Could not rename directory {directory}"
-        logging.critical(msg)
+        log.critical(msg)
         raise RuntimeError(msg) from e
 
 

--- a/src/uwtools/utils/processing.py
+++ b/src/uwtools/utils/processing.py
@@ -2,18 +2,19 @@
 Utilities for interacting with external processes.
 """
 
-import logging
 from pathlib import Path
 from subprocess import STDOUT, CalledProcessError, check_output
 from types import SimpleNamespace as ns
 from typing import Dict, Optional, Union
+
+from uwtools.logging import log
 
 
 def execute(
     cmd: str,
     cwd: Optional[Union[Path, str]] = None,
     env: Optional[Dict[str, str]] = None,
-    log: Optional[bool] = False,
+    log_output: Optional[bool] = False,
 ) -> ns:
     """
     Execute a command in a subshell.
@@ -21,30 +22,30 @@ def execute(
     :param cmd: The command to execute.
     :param cwd: Change to this directory before executing cmd.
     :param env: Environment variables to set before executing cmd.
-    :param log: Log output from successful cmd? (Error output is always logged.)
+    :param log_output: Log output from successful cmd? (Error output is always logged.)
     :return: A result object providing combined stder/stdout output and success values.
     """
 
     indent = "  "
-    logging.info("Executing: %s", cmd)
+    log.info("Executing: %s", cmd)
     if cwd:
-        logging.info("%sin %s", indent, cwd)
+        log.info("%sin %s", indent, cwd)
     if env:
-        logging.info("%swith environment variables:", indent)
+        log.info("%swith environment variables:", indent)
         for key, val in env.items():
-            logging.info("%s%s=%s", indent * 2, key, val)
+            log.info("%s%s=%s", indent * 2, key, val)
     try:
         output = check_output(
             cmd, cwd=cwd, encoding="utf=8", env=env, shell=True, stderr=STDOUT, text=True
         )
-        logfunc = logging.info
+        logfunc = log.info
         success = True
     except CalledProcessError as e:
         output = e.output
-        logging.error("%sFailed with status: %s", indent, e.returncode)
-        logfunc = logging.error
+        log.error("%sFailed with status: %s", indent, e.returncode)
+        logfunc = log.error
         success = False
-    if output and (log or not success):
+    if output and (log_output or not success):
         logfunc("%sOutput:", indent)
         for line in output.split("\n"):
             logfunc("%s%s", indent * 2, line)


### PR DESCRIPTION
**Description**

As a prelude to API work, add a capability to replace the default `uwtools` logger (i.e. the Python root logger) with an arbitrary logger. This will allow API users to configure `uwtools` to use any logger they like, to obtain custom formatting, logging to a file, to suppress logging entirely, etc.

There are a small number of changes in this PR that are not duplicates. Most of the diffs consist of replacing `import logging` statements with `from uwtools.logging import log`, and `loging.info()` (also .`debug()`, `.error()`, etc.) with `log.info()` (etc.) calls. See inline PR comments.

**Type of change**

- [x] New feature (non-breaking change which adds functionality)

**How Has This Been Tested?**

`make test` in a dev shell + GitHub Actions.
**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
