### PR TITLE
UW-413: Ensure CLI functions accept file and stdin streams for both input and output

### DIFF
--- a/src/uwtools/cli.py
+++ b/src/uwtools/cli.py
@@ -372,7 +372,7 @@ def _dispatch_rocoto_realize(args: Namespace) -> bool:
     :param args: Parsed command-line args.
     """
     success = uwtools.rocoto.realize_rocoto_xml(
-        config_file=args.input_file, rendered_output=args.output_file
+        config_file=args.input_file, output_file=args.output_file
     )
     return success
 

--- a/src/uwtools/cli.py
+++ b/src/uwtools/cli.py
@@ -332,10 +332,9 @@ def _add_subparser_rocoto_realize(subparsers: Subparsers) -> SubmodeChecks:
     :param subparsers: Parent parser's subparsers, to add this subparser to.
     """
     parser = _add_subparser(subparsers, STR.realize, "Realize a Rocoto XML workflow document")
-    required = parser.add_argument_group(TITLE_REQ_ARG)
-    _add_arg_output_file(required)
     optional = _basic_setup(parser)
     _add_arg_input_file(optional)
+    _add_arg_output_file(optional)
     checks = _add_args_quiet_and_verbose(optional)
     return checks
 

--- a/src/uwtools/config/atparse_to_jinja2.py
+++ b/src/uwtools/config/atparse_to_jinja2.py
@@ -4,14 +4,13 @@ Utilities for rendering Jinja2 templates.
 
 import logging
 import re
-from typing import IO, Any, Generator
+from typing import IO, Any, Generator, Optional
 
-from uwtools.types import OptionalPath
 from uwtools.utils.file import readable, writable
 
 
 def convert(
-    input_file: OptionalPath = None, output_file: OptionalPath = None, dry_run: bool = False
+    input_file: Optional[str] = None, output_file: Optional[str] = None, dry_run: bool = False
 ) -> None:
     """
     Replaces atparse @[] tokens with Jinja2 {{}} equivalents.

--- a/src/uwtools/config/atparse_to_jinja2.py
+++ b/src/uwtools/config/atparse_to_jinja2.py
@@ -4,13 +4,14 @@ Utilities for rendering Jinja2 templates.
 
 import logging
 import re
-from typing import IO, Any, Generator, Optional
+from typing import IO, Any, Generator
 
+from uwtools.types import OptionalPath
 from uwtools.utils.file import readable, writable
 
 
 def convert(
-    input_file: Optional[str] = None, output_file: Optional[str] = None, dry_run: bool = False
+    input_file: OptionalPath = None, output_file: OptionalPath = None, dry_run: bool = False
 ) -> None:
     """
     Replaces atparse @[] tokens with Jinja2 {{}} equivalents.

--- a/src/uwtools/config/j2template.py
+++ b/src/uwtools/config/j2template.py
@@ -8,7 +8,7 @@ from typing import List, Optional, Set
 from jinja2 import BaseLoader, Environment, FileSystemLoader, Template, meta
 
 from uwtools.logging import log
-from uwtools.types import DefinitePath, OptionalPath
+from uwtools.types import OptionalPath
 from uwtools.utils.file import readable, writable
 
 

--- a/src/uwtools/config/j2template.py
+++ b/src/uwtools/config/j2template.py
@@ -8,8 +8,8 @@ from typing import List, Optional, Set
 
 from jinja2 import BaseLoader, Environment, FileSystemLoader, Template, meta
 
-from uwtools.types import DefinitePath, OptionalPath
-from uwtools.utils.file import readable
+from uwtools.types import OptionalPath
+from uwtools.utils.file import readable, writable
 
 
 class J2Template:
@@ -43,7 +43,7 @@ class J2Template:
 
     # Public methods
 
-    def dump(self, output_path: DefinitePath) -> None:
+    def dump(self, output_path: OptionalPath) -> None:
         """
         Write rendered template to the path provided.
 
@@ -51,7 +51,7 @@ class J2Template:
         """
         msg = f"Writing rendered template to output file: {output_path}"
         logging.debug(msg)
-        with open(output_path, "w+", encoding="utf-8") as f:
+        with writable(output_path) as f:
             print(self.render(), file=f)
 
     def render(self) -> str:

--- a/src/uwtools/config/j2template.py
+++ b/src/uwtools/config/j2template.py
@@ -8,8 +8,8 @@ from typing import List, Optional, Set
 
 from jinja2 import BaseLoader, Environment, FileSystemLoader, Template, meta
 
-from uwtools.types import OptionalPath
-from uwtools.utils.file import readable, writable
+from uwtools.types import DefinitePath, OptionalPath
+from uwtools.utils.file import readable
 
 
 class J2Template:
@@ -43,7 +43,7 @@ class J2Template:
 
     # Public methods
 
-    def dump(self, output_path: OptionalPath) -> None:
+    def dump(self, output_path: DefinitePath) -> None:
         """
         Write rendered template to the path provided.
 
@@ -51,7 +51,7 @@ class J2Template:
         """
         msg = f"Writing rendered template to output file: {output_path}"
         logging.debug(msg)
-        with writable(output_path) as f:
+        with open(output_path, "w+", encoding="utf-8") as f:
             print(self.render(), file=f)
 
     def render(self) -> str:

--- a/src/uwtools/config/j2template.py
+++ b/src/uwtools/config/j2template.py
@@ -8,7 +8,7 @@ from typing import List, Optional, Set
 from jinja2 import BaseLoader, Environment, FileSystemLoader, Template, meta
 
 from uwtools.logging import log
-from uwtools.types import OptionalPath
+from uwtools.types import DefinitePath, OptionalPath
 from uwtools.utils.file import readable, writable
 
 
@@ -79,7 +79,7 @@ class J2Template:
 
     # Private methods
 
-    def _load_file(self, template_path: OptionalPath) -> Template:
+    def _load_file(self, template_path: DefinitePath) -> Template:
         """
         Load the Jinja2 template from the file provided.
 

--- a/src/uwtools/rocoto.py
+++ b/src/uwtools/rocoto.py
@@ -76,7 +76,7 @@ def _rocoto_template_xml() -> DefinitePath:
 
 def _write_rocoto_xml(
     config_file: OptionalPath,
-    rendered_output: DefinitePath,
+    rendered_output: OptionalPath,
 ) -> None:
     """
     Render the Rocoto workflow defined in the given YAML to XML.
@@ -89,13 +89,13 @@ def _write_rocoto_xml(
 
     # Render the template.
     template = J2Template(values=values.data, template_path=_rocoto_template_xml())
-    template.dump(output_path=str(rendered_output))
+    template.dump(output_path=rendered_output)
 
 
 # Public functions
 def realize_rocoto_xml(
     config_file: OptionalPath,
-    rendered_output: DefinitePath,
+    rendered_output: OptionalPath,
 ) -> bool:
     """
     Realize the Rocoto workflow defined in the given YAML as XML. Validate both the YAML input and
@@ -119,7 +119,7 @@ def realize_rocoto_xml(
             # Validate the XML.
             if validate_rocoto_xml(input_xml=temp_file.name):
                 # If no issues were detected, save temp file and report success.
-                shutil.move(temp_file.name, rendered_output)
+                shutil.move(temp_file.name, str(rendered_output))
                 return True
         logging.error("Rocoto validation errors identified in %s", temp_file.name)
         return False

--- a/src/uwtools/rocoto.py
+++ b/src/uwtools/rocoto.py
@@ -89,7 +89,7 @@ def _write_rocoto_xml(
 
     # Render the template.
     template = J2Template(values=values.data, template_path=_rocoto_template_xml())
-    template.dump(output_path=rendered_output)
+    template.dump(output_path=str(rendered_output))
 
 
 # Public functions

--- a/src/uwtools/rocoto.py
+++ b/src/uwtools/rocoto.py
@@ -13,7 +13,7 @@ from uwtools.config.j2template import J2Template
 from uwtools.config.validator import validate_yaml
 from uwtools.logging import log
 from uwtools.types import DefinitePath, OptionalPath
-from uwtools.utils.file import readable
+from uwtools.utils.file import readable, writable
 
 # Private functions
 
@@ -119,8 +119,9 @@ def realize_rocoto_xml(
         return False
 
     if output_file is None:
-        with open(temp_file, "r", encoding="utf-8") as f:
-            print(f.read())
+        with open(temp_file, "r", encoding="utf-8") as f_in:
+            with writable(output_file) as f_out:
+                print(f_in.read(), file=f_out)
         Path(temp_file).unlink()
     else:
         Path(temp_file).rename(output_file)
@@ -135,7 +136,7 @@ def validate_rocoto_xml(input_xml: OptionalPath) -> bool:
     :return: Did the XML file conform to the schema?
     """
     with readable(input_xml) as f:
-        tree = etree.parse(f)
+        tree = etree.fromstring(bytes(f.read(), encoding="utf-8"))
     with open(_rocoto_schema_xml(), "r", encoding="utf-8") as f:
         schema = etree.RelaxNG(etree.parse(f))
     valid = schema.validate(tree)

--- a/src/uwtools/rocoto.py
+++ b/src/uwtools/rocoto.py
@@ -89,7 +89,7 @@ def _write_rocoto_xml(
 
     # Render the template.
     template = J2Template(values=values.data, template_path=_rocoto_template_xml())
-    template.dump(output_path=str(rendered_output))
+    template.dump(output_path=rendered_output)
 
 
 # Public functions

--- a/src/uwtools/rocoto.py
+++ b/src/uwtools/rocoto.py
@@ -110,8 +110,8 @@ def realize_rocoto_xml(
         log.error("YAML validation errors identified in %s", config_file)
         return False
 
-    with tempfile.NamedTemporaryFile(delete=False) as temp_file:
-        _write_rocoto_xml(config_file=config_file, rendered_output=temp_file.name)
+    temp_file = tempfile.NamedTemporaryFile(delete=False)  # pylint: disable=consider-using-with
+    _write_rocoto_xml(config_file=config_file, rendered_output=temp_file.name)
 
     if not validate_rocoto_xml(input_xml=temp_file.name):
         log.error("Rocoto validation errors identified in %s", temp_file.name)
@@ -120,6 +120,7 @@ def realize_rocoto_xml(
     if rendered_output is None:
         with open(temp_file.name, "r", encoding="utf-8") as f:
             print(f.read())
+        Path(temp_file.name).unlink()
     else:
         Path(temp_file.name).rename(rendered_output)
     return True
@@ -132,20 +133,14 @@ def validate_rocoto_xml(input_xml: OptionalPath) -> bool:
     :param input_xml: Path to rendered XML file.
     :return: Did the XML file conform to the schema?
     """
-
-    # Validate the XML.
+    with readable(input_xml) as f:
+        tree = etree.parse(f)
     with open(_rocoto_schema_xml(), "r", encoding="utf-8") as f:
         schema = etree.RelaxNG(etree.parse(f))
-    with readable(input_xml) as f:
-        xml = f.read()
-    tree = etree.fromstring(bytes(xml, encoding="utf-8"))
-    success = schema.validate(tree)
-
-    # Log validation errors.
-    errors = str(etree.RelaxNG.error_log).split("\n")
-    log_method = log.error if len(errors) else log.info
-    log_method("%s Rocoto validation error%s found", len(errors), "" if len(errors) == 1 else "s")
-    for line in errors:
-        log.error(line)
-
-    return success
+    valid = schema.validate(tree)
+    nerr = len(schema.error_log)
+    log_method = log.info if valid else log.error
+    log_method("%s Rocoto validation error%s found", nerr, "" if nerr == 1 else "s")
+    for err in list(schema.error_log):
+        log.error(err)
+    return valid

--- a/src/uwtools/rocoto.py
+++ b/src/uwtools/rocoto.py
@@ -118,13 +118,10 @@ def realize_rocoto_xml(
         log.error("Rocoto validation errors identified in %s", temp_file)
         return False
 
-    if output_file is None:
-        with open(temp_file, "r", encoding="utf-8") as f_in:
-            with writable(output_file) as f_out:
-                print(f_in.read(), file=f_out)
-        Path(temp_file).unlink()
-    else:
-        Path(temp_file).rename(output_file)
+    with open(temp_file, "r", encoding="utf-8") as f_in:
+        with writable(output_file) as f_out:
+            print(f_in.read(), file=f_out)
+    Path(temp_file).unlink()
     return True
 
 

--- a/src/uwtools/tests/test_rocoto.py
+++ b/src/uwtools/tests/test_rocoto.py
@@ -11,6 +11,7 @@ import pytest
 import yaml
 
 from uwtools import rocoto
+from uwtools.config import validator
 from uwtools.config.core import YAMLConfig
 from uwtools.tests import support
 
@@ -75,18 +76,27 @@ def test_realize_rocoto_xml(vals, tmp_path):
     output = tmp_path / "rendered.xml"
 
     with patch.object(rocoto, "validate_rocoto_xml", value=True):
-        with patch.object(rocoto.uwtools.config.validator, "_bad_paths", return_value=None):
+        with patch.object(validator, "_bad_paths", return_value=None):
             with resources.as_file(resources.files("uwtools.tests.fixtures")) as path:
                 config_file = path / fn
                 result = rocoto.realize_rocoto_xml(config_file=config_file, rendered_output=output)
     assert result is validity
 
 
+def test_realize_rocoto_default_output():
+    with patch.object(rocoto, "validate_rocoto_xml", value=True):
+        with patch.object(validator, "_bad_paths", return_value=None):
+            with resources.as_file(resources.files("uwtools.tests.fixtures")) as path:
+                config_file = path / "hello_workflow.yaml"
+                result = rocoto.realize_rocoto_xml(config_file=config_file)
+    assert result is True
+
+
 def test_realize_rocoto_invalid_xml():
     config_file = support.fixture_path("hello_workflow.yaml")
     xml = support.fixture_path("rocoto_invalid.xml")
     with patch.object(rocoto, "_write_rocoto_xml", return_value=None):
-        with patch.object(rocoto.uwtools.config.validator, "_bad_paths", return_value=None):
+        with patch.object(validator, "_bad_paths", return_value=None):
             with patch.object(tempfile, "NamedTemporaryFile") as context_manager:
                 context_manager.return_value.__enter__.return_value.name = xml
                 result = rocoto.realize_rocoto_xml(config_file=config_file, rendered_output=xml)

--- a/src/uwtools/tests/test_rocoto.py
+++ b/src/uwtools/tests/test_rocoto.py
@@ -77,7 +77,7 @@ def test_realize_rocoto_xml(vals, tmp_path):
     with patch.object(rocoto, "validate_rocoto_xml", value=True):
         with resources.as_file(resources.files("uwtools.tests.fixtures")) as path:
             config_file = path / fn
-            result = rocoto.realize_rocoto_xml(config_file=config_file, rendered_output=output)
+            result = rocoto.realize_rocoto_xml(config_file=config_file, output_file=output)
     assert result is validity
 
 
@@ -93,9 +93,8 @@ def test_realize_rocoto_invalid_xml():
     config_file = support.fixture_path("hello_workflow.yaml")
     xml = support.fixture_path("rocoto_invalid.xml")
     with patch.object(rocoto, "_write_rocoto_xml", return_value=None):
-        with patch.object(tempfile, "NamedTemporaryFile") as temp:
-            temp.return_value.name = xml
-            result = rocoto.realize_rocoto_xml(config_file=config_file, rendered_output=xml)
+        with patch.object(tempfile, "mkstemp", return_value=(None, xml)):
+            result = rocoto.realize_rocoto_xml(config_file=config_file, output_file=xml)
     assert result is False
 
 
@@ -112,7 +111,7 @@ def test__write_rocoto_xml(tmp_path):
     config_file = support.fixture_path("hello_workflow.yaml")
     output = tmp_path / "rendered.xml"
 
-    rocoto._write_rocoto_xml(config_file=config_file, rendered_output=output)
+    rocoto._write_rocoto_xml(config_file=config_file, output_file=output)
 
     expected = support.fixture_path("hello_workflow.xml")
     assert support.compare_files(expected, output) is True

--- a/src/uwtools/tests/test_rocoto.py
+++ b/src/uwtools/tests/test_rocoto.py
@@ -11,7 +11,6 @@ import pytest
 import yaml
 
 from uwtools import rocoto
-from uwtools.config import validator
 from uwtools.config.core import YAMLConfig
 from uwtools.tests import support
 
@@ -84,10 +83,9 @@ def test_realize_rocoto_xml(vals, tmp_path):
 
 def test_realize_rocoto_default_output():
     with patch.object(rocoto, "validate_rocoto_xml", value=True):
-        with patch.object(validator, "_bad_paths", return_value=None):
-            with resources.as_file(resources.files("uwtools.tests.fixtures")) as path:
-                config_file = path / "hello_workflow.yaml"
-                result = rocoto.realize_rocoto_xml(config_file=config_file)
+        with resources.as_file(resources.files("uwtools.tests.fixtures")) as path:
+            config_file = path / "hello_workflow.yaml"
+            result = rocoto.realize_rocoto_xml(config_file=config_file)
     assert result is True
 
 
@@ -95,8 +93,8 @@ def test_realize_rocoto_invalid_xml():
     config_file = support.fixture_path("hello_workflow.yaml")
     xml = support.fixture_path("rocoto_invalid.xml")
     with patch.object(rocoto, "_write_rocoto_xml", return_value=None):
-        with patch.object(tempfile, "NamedTemporaryFile") as context_manager:
-            context_manager.return_value.__enter__.return_value.name = xml
+        with patch.object(tempfile, "NamedTemporaryFile") as temp:
+            temp.return_value.name = xml
             result = rocoto.realize_rocoto_xml(config_file=config_file, rendered_output=xml)
     assert result is False
 

--- a/src/uwtools/tests/test_rocoto.py
+++ b/src/uwtools/tests/test_rocoto.py
@@ -97,8 +97,8 @@ def test_realize_rocoto_invalid_xml():
     xml = support.fixture_path("rocoto_invalid.xml")
     with patch.object(rocoto, "_write_rocoto_xml", return_value=None):
         with patch.object(validator, "_bad_paths", return_value=None):
-            with patch.object(tempfile, "NamedTemporaryFile") as context_manager:
-                context_manager.return_value.__enter__.return_value.name = xml
+            with patch.object(tempfile, "NamedTemporaryFile") as temp:
+                temp.return_value.name = xml
                 result = rocoto.realize_rocoto_xml(config_file=config_file, rendered_output=xml)
     assert result is False
 


### PR DESCRIPTION
**Description**
Calls to `DefinitePath` and `Str` will need to be updated to `OptionalPath` and tests should also be expanded as necessary to ensure this works correctly.

Created from PR #316 , Fixes issue #323 

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] pytests in GitHub actions.
- [x] Tests on Ubuntu OS

**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes need updates to the documentation.  I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [x] Any dependent changes have been merged and published
