### PR TITLE
rereadable-stdin

### DIFF
--- a/src/pyproject.toml
+++ b/src/pyproject.toml
@@ -37,7 +37,6 @@ disable = [
   "too-many-instance-attributes",
   "too-many-lines",
   "too-many-locals",
-  "too-many-statements",
   "unnecessary-lambda-assignment",
   "use-dict-literal",
 ]

--- a/src/uwtools/config/core.py
+++ b/src/uwtools/config/core.py
@@ -533,7 +533,7 @@ class YAMLConfig(Config):
         loader = self._yaml_loader
         with readable(config_file) as f:
             try:
-                cfg = yaml.load(f, Loader=loader)
+                cfg = yaml.load(f.read(), Loader=loader)
             except yaml.constructor.ConstructorError as e:
                 if e.problem:
                     if "unhashable" in e.problem:

--- a/src/uwtools/config/validator.py
+++ b/src/uwtools/config/validator.py
@@ -3,8 +3,7 @@ Support for validating a config using JSON Schema.
 """
 
 import json
-from pathlib import Path
-from typing import List, Optional
+from typing import List
 
 import jsonschema
 
@@ -15,16 +14,13 @@ from uwtools.types import DefinitePath, OptionalPath
 # Public functions
 
 
-def validate_yaml(
-    schema_file: DefinitePath, config_file: OptionalPath = None, check_paths: Optional[bool] = True
-) -> bool:
+def validate_yaml(schema_file: DefinitePath, config_file: OptionalPath = None) -> bool:
     """
     Check whether the given config file conforms to the given JSON Schema spec and whether any
     filesystem paths it identifies do not exist.
 
     :param schema_file: The JSON Schema file to use for validation.
     :param config_file: The YAML file to validate (stdin will be used by default)
-    :param check_paths: Check for filesystem paths that do not exist
     :return: Did the YAML file conform to the schema?
     """
     # Load the config and schema.
@@ -42,35 +38,11 @@ def validate_yaml(
     # It's pointless to evaluate an invalid config, so return now if that's the case.
     if errors:
         return False
-    # Collect and report bad paths found in config.
-    if check_paths:
-        if bad_paths := _bad_paths(yaml_config.data, schema):
-            for bad_path in bad_paths:
-                log.error("Path does not exist: %s", bad_path)
-            return False
     # If no issues were detected, report success.
     return True
 
 
 # Private functions
-
-
-def _bad_paths(config: dict, schema: dict) -> List[str]:
-    """
-    Identify non-existent config paths.
-
-    The schema has the same shape as the config, so traverse them together, recursively, checking
-    values identified by the schema as having "uri" format, which denotes a path.
-    """
-    paths = []
-    for key, val in config.items():
-        subschema = schema.get("properties", {}).get(key, {})
-        if isinstance(val, dict):
-            paths += _bad_paths(val, subschema)
-        else:
-            if subschema.get("format") == "uri" and not Path(val).exists():
-                paths.append(val)
-    return sorted(paths)
 
 
 def _validation_errors(config: dict, schema: dict) -> List[str]:

--- a/src/uwtools/tests/config/test_atparse_to_jinja2.py
+++ b/src/uwtools/tests/config/test_atparse_to_jinja2.py
@@ -12,6 +12,7 @@ from pytest import fixture
 
 from uwtools.config import atparse_to_jinja2
 from uwtools.logging import log
+from uwtools.utils.file import _stdinproxy
 
 # Helper functions
 
@@ -67,6 +68,7 @@ def test_convert_input_file_to_stdout(atparsefile, capsys, jinja2txt):
 
 def test_convert_stdin_to_file(atparselines, capsys, jinja2txt, tmp_path):
     outfile = tmp_path / "outfile"
+    _stdinproxy.cache_clear()
     with patch.object(sys, "stdin", new=StringIO("\n".join(atparselines))):
         atparse_to_jinja2.convert(output_file=outfile)
     with open(outfile, "r", encoding="utf-8") as f:
@@ -79,6 +81,7 @@ def test_convert_stdin_to_file(atparselines, capsys, jinja2txt, tmp_path):
 def test_convert_stdin_to_logging(atparselines, caplog, jinja2txt, tmp_path):
     log.setLevel(logging.INFO)
     outfile = tmp_path / "outfile"
+    _stdinproxy.cache_clear()
     with patch.object(sys, "stdin", new=StringIO("\n".join(atparselines))):
         atparse_to_jinja2.convert(output_file=outfile, dry_run=True)
     assert "\n".join(record.message for record in caplog.records) == jinja2txt.strip()
@@ -86,6 +89,7 @@ def test_convert_stdin_to_logging(atparselines, caplog, jinja2txt, tmp_path):
 
 
 def test_convert_stdin_to_stdout(atparselines, capsys, jinja2txt):
+    _stdinproxy.cache_clear()
     with patch.object(sys, "stdin", new=StringIO("\n".join(atparselines))):
         atparse_to_jinja2.convert()
     streams = capsys.readouterr()

--- a/src/uwtools/tests/config/test_core.py
+++ b/src/uwtools/tests/config/test_core.py
@@ -7,6 +7,7 @@ import datetime
 import filecmp
 import logging
 import os
+import sys
 from collections import OrderedDict
 from io import StringIO
 from pathlib import Path
@@ -22,7 +23,7 @@ from uwtools.config import core
 from uwtools.exceptions import UWConfigError
 from uwtools.logging import log
 from uwtools.tests.support import compare_files, fixture_path, logged
-from uwtools.utils.file import FORMAT, path_if_it_exists, writable
+from uwtools.utils.file import FORMAT, _stdinproxy, path_if_it_exists, writable
 
 # Test functions
 
@@ -917,8 +918,9 @@ def test_YAMLConfig__load_paths_failure_stdin_plus_relpath(caplog):
     # is meaningless relative to stdin, assert that an appropriate error is logged and exception
     # raised.
     log.setLevel(logging.INFO)
+    _stdinproxy.cache_clear()
     relpath = "../bar/baz.yaml"
-    with patch.object(core.sys, "stdin", new=StringIO(f"foo: {core.INCLUDE_TAG} [{relpath}]")):
+    with patch.object(sys, "stdin", new=StringIO(f"foo: {core.INCLUDE_TAG} [{relpath}]")):
         with raises(UWConfigError) as e:
             core.YAMLConfig()
     msg = f"Reading from stdin, a relative path was encountered: {relpath}"

--- a/src/uwtools/tests/test_rocoto.py
+++ b/src/uwtools/tests/test_rocoto.py
@@ -75,10 +75,9 @@ def test_realize_rocoto_xml(vals, tmp_path):
     output = tmp_path / "rendered.xml"
 
     with patch.object(rocoto, "validate_rocoto_xml", value=True):
-        with patch.object(rocoto.uwtools.config.validator, "_bad_paths", return_value=None):
-            with resources.as_file(resources.files("uwtools.tests.fixtures")) as path:
-                config_file = path / fn
-                result = rocoto.realize_rocoto_xml(config_file=config_file, rendered_output=output)
+        with resources.as_file(resources.files("uwtools.tests.fixtures")) as path:
+            config_file = path / fn
+            result = rocoto.realize_rocoto_xml(config_file=config_file, rendered_output=output)
     assert result is validity
 
 
@@ -86,10 +85,9 @@ def test_realize_rocoto_invalid_xml():
     config_file = support.fixture_path("hello_workflow.yaml")
     xml = support.fixture_path("rocoto_invalid.xml")
     with patch.object(rocoto, "_write_rocoto_xml", return_value=None):
-        with patch.object(rocoto.uwtools.config.validator, "_bad_paths", return_value=None):
-            with patch.object(tempfile, "NamedTemporaryFile") as context_manager:
-                context_manager.return_value.__enter__.return_value.name = xml
-                result = rocoto.realize_rocoto_xml(config_file=config_file, rendered_output=xml)
+        with patch.object(tempfile, "NamedTemporaryFile") as context_manager:
+            context_manager.return_value.__enter__.return_value.name = xml
+            result = rocoto.realize_rocoto_xml(config_file=config_file, rendered_output=xml)
     assert result is False
 
 

--- a/src/uwtools/tests/utils/test_file.py
+++ b/src/uwtools/tests/utils/test_file.py
@@ -1,10 +1,11 @@
-# pylint: disable=missing-function-docstring,redefined-outer-name
+# pylint: disable=missing-function-docstring,protected-access,redefined-outer-name
 """
 Tests for uwtools.utils.file module.
 """
 
 import sys
 from datetime import datetime as dt
+from io import StringIO
 from unittest.mock import patch
 
 import pytest
@@ -22,6 +23,35 @@ def assets(tmp_path):
     renamed = rundir.parent / ("rundir_%s" % now.strftime("%Y%m%d_%H%M%S"))
     assert not renamed.is_dir()
     return now, renamed, rundir
+
+
+def test_StdinProxy():
+    msg = "proxying stdin"
+    with patch.object(sys, "stdin", new=StringIO(msg)):
+        assert sys.stdin.read() == msg
+        # Reading from stdin a second time yields no input, as the stream has been exhausted:
+        assert sys.stdin.read() == ""
+    with patch.object(sys, "stdin", new=StringIO(msg)):
+        sp = file.StdinProxy()
+        assert sp.read() == msg
+        # But the stdin proxy can be read multiple times:
+        assert sp.read() == msg
+
+
+def test__stdinproxy():
+    file._stdinproxy.cache_clear()
+    msg0 = "hello world"
+    msg1 = "bonjour monde"
+    # Unsurprisingly, the first read from stdin finds the expected message:
+    with patch.object(sys, "stdin", new=StringIO(msg0)):
+        assert file._stdinproxy().read() == msg0
+    # But after re-patching stdin with a new message, a second read returns the old message:
+    with patch.object(sys, "stdin", new=StringIO(msg1)):
+        assert file._stdinproxy().read() == msg0  # <-- the OLD message
+    # However, if the cache is cleared, the second message is then read:
+    file._stdinproxy.cache_clear()
+    with patch.object(sys, "stdin", new=StringIO(msg1)):
+        assert file._stdinproxy().read() == msg1  # <-- the NEW message
 
 
 def test_get_file_type():

--- a/src/uwtools/tests/utils/test_file.py
+++ b/src/uwtools/tests/utils/test_file.py
@@ -103,7 +103,7 @@ def test_readable_file(tmp_path):
 
 def test_readable_nofile():
     with file.readable() as f:
-        assert f is sys.stdin
+        assert hasattr(f, "read")
 
 
 def test_writable_file(tmp_path):


### PR DESCRIPTION
Two small things in this PR to assist with [UW-413](https://jira.epic.oarcloud.noaa.gov/browse/UW-413):

1. Address [UW-414](https://jira.epic.oarcloud.noaa.gov/browse/UW-414) by removing `_bad_paths()` and updating associated code, and
2. Supporting multiple reads of the same data from `stdin`.

In re item 2., although it's probably not optimal design, UW currently reads the same config file multiple times. Best practice would be to minimize file IO and re-use already-read in-memory data, but that wouldn't be easy to address quickly. (But we should keep it in mind as a potential design goal going forward IMO).

However, stdin is a stream that, once read, is exhausted and cannot be read again. In `realize_rocoto_xml()` in module `uwtools.rocoto`, we currently read the config (file) once via `validate_yaml()`, then again via the `YAMLConfig(input_yaml)` call in `_add_jobname_to_tasks()`, which is called by `_write_rocoto_xml()`. That's fine, if not optimal, with on-disk files, but doesn't work when reading from a stream. Ideally, we'd read the stream into a string once and access the string as needed, but that might require some significant re-plumbing. For now, provide a proxy in front of stdin that permits the data read from that stream to be re-read as often as needed.