### PR TITLE
post-uw-376-items

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,8 +97,9 @@ In addition to the `make devshell` command, two other `make` targets are availab
 
 | Command          | Description                                                |
 | ---------------- | ---------------------------------------------------------- |
-| `make package`   | Builds a `uwtools` conda package                           |
 | `make env`       | Creates a conda environment based on the `uwtools` code    |
+| `make meta`      | Update `recipe/meta.json` from `recipe/meta.yaml`          |
+| `make package`   | Builds a `uwtools` conda package                           |
 
 These targets work from the code in its current state in the clone. `make env` calls `make package` automatically to create a local package, then builds an environment based on the package.
 
@@ -123,7 +124,7 @@ The following files in this repo are derived from their counterparts in the [con
 │   ├── build.sh
 │   ├── channels
 │   ├── conda_build_config.yaml
-│   ├── .gitignore
+│   ├── meta.json
 │   ├── meta.yaml
 │   └── run_test.sh
 ├── src

--- a/src/uwtools/cli.py
+++ b/src/uwtools/cli.py
@@ -775,7 +775,7 @@ def _switch(arg: str) -> str:
 
 
 @dataclass(frozen=True)
-class _STR:
+class STR:
     """
     A lookup map for CLI-related strings.
     """
@@ -812,6 +812,3 @@ class _STR:
     valsfmt: str = "values_format"
     valsneeded: str = "values_needed"
     verbose: str = "verbose"
-
-
-STR = _STR()

--- a/src/uwtools/rocoto.py
+++ b/src/uwtools/rocoto.py
@@ -295,7 +295,7 @@ class _RocotoXML:
 
 
 @dataclass(frozen=True)
-class _STR:
+class STR:
     """
     A lookup map for Rocoto-related strings.
     """
@@ -335,6 +335,3 @@ class _STR:
     var: str = "var"
     walltime: str = "walltime"
     workflow: str = "workflow"
-
-
-STR = _STR()

--- a/src/uwtools/tests/test_rocoto.py
+++ b/src/uwtools/tests/test_rocoto.py
@@ -66,26 +66,26 @@ class Test_RocotoXML:
     def root(self):
         return rocoto.Element("root")
 
-    def test__RocotoXML__doctype_entities(self, instance):
+    def test__doctype_entities(self, instance):
         assert '<!ENTITY ACCOUNT "myaccount">' in instance._doctype
         assert '<!ENTITY FOO "test.log">' in instance._doctype
 
-    def test__RocotoXML__doctype_entities_none(self, instance):
+    def test__doctype_entities_none(self, instance):
         del instance._config["workflow"]["entities"]
         assert instance._doctype is None
 
-    def test__RocotoXML__config_validate(self, assets, instance):
+    def test__config_validate(self, assets, instance):
         cfgfile, _ = assets
         instance._config_validate(config_file=cfgfile)
 
-    def test__RocotoXML__config_validate_fail(self, instance, tmp_path):
+    def test__config_validate_fail(self, instance, tmp_path):
         cfgfile = tmp_path / "bad.yaml"
         with open(cfgfile, "w", encoding="utf-8") as f:
             print("not: ok", file=f)
         with raises(UWConfigError):
             instance._config_validate(config_file=cfgfile)
 
-    def test__RocotoXML__add_metatask(self, instance, root):
+    def test__add_metatask(self, instance, root):
         config = {"metatask_foo": "1", "task_bar": "2", "var": {"baz": "3", "qux": "4"}}
         taskname = "test-metatask"
         orig = instance._add_metatask
@@ -97,7 +97,7 @@ class Test_RocotoXML:
         mocks["_add_metatask"].assert_called_once_with(metatask, "1", "foo")
         mocks["_add_task"].assert_called_once_with(metatask, "2", "bar")
 
-    def test__RocotoXML__add_task(self, instance, root):
+    def test__add_task(self, instance, root):
         config = {
             "attrs": {"foo": "1", "bar": "2"},
             "account": "baz",
@@ -115,7 +115,7 @@ class Test_RocotoXML:
         mocks["_add_task_dependency"].assert_called_once_with(task, "qux")
         mocks["_add_task_envar"].assert_called_once_with(task, "A", "apple")
 
-    def test__RocotoXML__add_task_dependency(self, instance, root):
+    def test__add_task_dependency(self, instance, root):
         config = {"taskdep": {"attrs": {"task": "foo"}}}
         instance._add_task_dependency(e=root, config=config)
         dependency = root[0]
@@ -124,12 +124,12 @@ class Test_RocotoXML:
         assert taskdep.tag == "taskdep"
         assert taskdep.get("task") == "foo"
 
-    def test__RocotoXML__add_task_dependency_fail(self, instance, root):
+    def test__add_task_dependency_fail(self, instance, root):
         config = {"unrecognized": "whatever"}
         with raises(UWConfigError):
             instance._add_task_dependency(e=root, config=config)
 
-    def test__RocotoXML__add_task_envar(self, instance, root):
+    def test__add_task_envar(self, instance, root):
         instance._add_task_envar(root, "foo", "bar")
         envar = root[0]
         name, value = envar
@@ -138,7 +138,7 @@ class Test_RocotoXML:
         assert value.tag == "value"
         assert value.text == "bar"
 
-    def test__RocotoXML__add_workflow(self, instance):
+    def test__add_workflow(self, instance):
         config = {
             "workflow": {
                 "attrs": {"foo": "1", "bar": "2"},
@@ -159,7 +159,7 @@ class Test_RocotoXML:
         mocks["_add_workflow_log"].assert_called_once_with(workflow, "4")
         mocks["_add_workflow_tasks"].assert_called_once_with(workflow, "5")
 
-    def test__RocotoXML__add_workflow_cycledefs(self, instance, root):
+    def test__add_workflow_cycledefs(self, instance, root):
         config = {"foo": ["1", "2"], "bar": ["3", "4"]}
         instance._add_workflow_cycledefs(e=root, config=config)
         for i, group, coord in [(0, "foo", "1"), (1, "foo", "2"), (2, "bar", "3"), (3, "bar", "4")]:
@@ -167,31 +167,31 @@ class Test_RocotoXML:
             assert root[i].get("group") == group
             assert root[i].text == coord
 
-    def test__RocotoXML__add_workflow_log(self, instance, root):
+    def test__add_workflow_log(self, instance, root):
         path = "/path/to/logfile"
         instance._add_workflow_log(e=root, logfile=path)
         log = root[0]
         assert log.tag == "log"
         assert log.text == path
 
-    def test__RocotoXML__add_workflow_tasks(self, instance, root):
+    def test__add_workflow_tasks(self, instance, root):
         config = {"metatask_foo": "1", "task_bar": "2"}
         with patch.multiple(instance, _add_metatask=D, _add_task=D) as mocks:
             instance._add_workflow_tasks(e=root, config=config)
         mocks["_add_metatask"].assert_called_once_with(root, "1", "foo")
         mocks["_add_task"].assert_called_once_with(root, "2", "bar")
 
-    def test__RocotoXML__insert_doctype(self, instance):
+    def test__insert_doctype(self, instance):
         with patch.object(rocoto._RocotoXML, "_doctype", new_callable=PropertyMock) as _doctype:
             _doctype.return_value = "bar"
             assert instance._insert_doctype("foo\nbaz\n") == "foo\nbar\nbaz\n"
 
-    def test__RocotoXML__insert_doctype_none(self, instance):
+    def test__insert_doctype_none(self, instance):
         with patch.object(rocoto._RocotoXML, "_doctype", new_callable=PropertyMock) as _doctype:
             _doctype.return_value = None
             assert instance._insert_doctype("foo\nbaz\n") == "foo\nbaz\n"
 
-    def test__RocotoXML__set_and_render_jobname(self, instance):
+    def test__set_and_render_jobname(self, instance):
         config = {"foo": "{{ jobname }}", "baz": "{{ qux }}"}
         assert instance._set_and_render_jobname(config=config, taskname="bar") == {
             "jobname": "bar",  # set
@@ -199,13 +199,13 @@ class Test_RocotoXML:
             "baz": "{{ qux }}",  # ignored
         }
 
-    def test__RocotoXML__setattrs(self, instance, root):
+    def test__setattrs(self, instance, root):
         config = {"attrs": {"foo": "1", "bar": "2"}}
         instance._set_attrs(e=root, config=config)
         assert root.get("foo") == "1"
         assert root.get("bar") == "2"
 
-    def test__RocotoXML__tag_name(self, instance):
+    def test__tag_name(self, instance):
         assert instance._tag_name("foo") == ("foo", "")
         assert instance._tag_name("foo_bar") == ("foo", "bar")
         assert instance._tag_name("foo_bar_baz") == ("foo", "bar_baz")

--- a/src/uwtools/tests/test_rocoto.py
+++ b/src/uwtools/tests/test_rocoto.py
@@ -22,17 +22,6 @@ def assets(tmp_path):
     return fixture_path("hello_workflow.yaml"), tmp_path / "rocoto.xml"
 
 
-@fixture
-def instance(assets):
-    cfgfile, _ = assets
-    return rocoto._RocotoXML(config_file=cfgfile)
-
-
-@fixture
-def root():
-    return rocoto.Element("root")
-
-
 # Tests
 
 
@@ -63,158 +52,160 @@ def test_validate_rocoto_xml(vals):
     assert rocoto.validate_rocoto_xml(input_xml=xml) is validity
 
 
-def test__RocotoXML__doctype_entities(instance):
-    assert '<!ENTITY ACCOUNT "myaccount">' in instance._doctype
-    assert '<!ENTITY FOO "test.log">' in instance._doctype
+class Test_RocotoXML:
+    """
+    Tests for class uwtools.rocoto._RocotoXML.
+    """
 
+    @fixture
+    def instance(self, assets):
+        cfgfile, _ = assets
+        return rocoto._RocotoXML(config_file=cfgfile)
 
-def test__RocotoXML__doctype_entities_none(instance):
-    del instance._config["workflow"]["entities"]
-    assert instance._doctype is None
+    @fixture
+    def root(self):
+        return rocoto.Element("root")
 
+    def test__RocotoXML__doctype_entities(self, instance):
+        assert '<!ENTITY ACCOUNT "myaccount">' in instance._doctype
+        assert '<!ENTITY FOO "test.log">' in instance._doctype
 
-def test__RocotoXML__config_validate(assets, instance):
-    cfgfile, _ = assets
-    instance._config_validate(config_file=cfgfile)
+    def test__RocotoXML__doctype_entities_none(self, instance):
+        del instance._config["workflow"]["entities"]
+        assert instance._doctype is None
 
-
-def test__RocotoXML__config_validate_fail(instance, tmp_path):
-    cfgfile = tmp_path / "bad.yaml"
-    with open(cfgfile, "w", encoding="utf-8") as f:
-        print("not: ok", file=f)
-    with raises(UWConfigError):
+    def test__RocotoXML__config_validate(self, assets, instance):
+        cfgfile, _ = assets
         instance._config_validate(config_file=cfgfile)
 
+    def test__RocotoXML__config_validate_fail(self, instance, tmp_path):
+        cfgfile = tmp_path / "bad.yaml"
+        with open(cfgfile, "w", encoding="utf-8") as f:
+            print("not: ok", file=f)
+        with raises(UWConfigError):
+            instance._config_validate(config_file=cfgfile)
 
-def test__RocotoXML__add_metatask(instance, root):
-    config = {"metatask_foo": "1", "task_bar": "2", "var": {"baz": "3", "qux": "4"}}
-    taskname = "test-metatask"
-    orig = instance._add_metatask
-    with patch.multiple(instance, _add_metatask=D, _add_task=D) as mocks:
-        orig(e=root, config=config, taskname=taskname)
-    metatask = root[0]
-    assert metatask.tag == "metatask"
-    assert metatask.get("name") == taskname
-    mocks["_add_metatask"].assert_called_once_with(metatask, "1", "foo")
-    mocks["_add_task"].assert_called_once_with(metatask, "2", "bar")
+    def test__RocotoXML__add_metatask(self, instance, root):
+        config = {"metatask_foo": "1", "task_bar": "2", "var": {"baz": "3", "qux": "4"}}
+        taskname = "test-metatask"
+        orig = instance._add_metatask
+        with patch.multiple(instance, _add_metatask=D, _add_task=D) as mocks:
+            orig(e=root, config=config, taskname=taskname)
+        metatask = root[0]
+        assert metatask.tag == "metatask"
+        assert metatask.get("name") == taskname
+        mocks["_add_metatask"].assert_called_once_with(metatask, "1", "foo")
+        mocks["_add_task"].assert_called_once_with(metatask, "2", "bar")
 
+    def test__RocotoXML__add_task(self, instance, root):
+        config = {
+            "attrs": {"foo": "1", "bar": "2"},
+            "account": "baz",
+            "dependency": "qux",
+            "envars": {"A": "apple"},
+        }
+        taskname = "test-task"
+        with patch.multiple(instance, _add_task_dependency=D, _add_task_envar=D) as mocks:
+            instance._add_task(e=root, config=config, taskname=taskname)
+        task = root[0]
+        assert task.tag == "task"
+        assert task.get("name") == taskname
+        assert task.get("foo") == "1"
+        assert task.get("bar") == "2"
+        mocks["_add_task_dependency"].assert_called_once_with(task, "qux")
+        mocks["_add_task_envar"].assert_called_once_with(task, "A", "apple")
 
-def test__RocotoXML__add_task(instance, root):
-    config = {
-        "attrs": {"foo": "1", "bar": "2"},
-        "account": "baz",
-        "dependency": "qux",
-        "envars": {"A": "apple"},
-    }
-    taskname = "test-task"
-    with patch.multiple(instance, _add_task_dependency=D, _add_task_envar=D) as mocks:
-        instance._add_task(e=root, config=config, taskname=taskname)
-    task = root[0]
-    assert task.tag == "task"
-    assert task.get("name") == taskname
-    assert task.get("foo") == "1"
-    assert task.get("bar") == "2"
-    mocks["_add_task_dependency"].assert_called_once_with(task, "qux")
-    mocks["_add_task_envar"].assert_called_once_with(task, "A", "apple")
-
-
-def test__RocotoXML__add_task_dependency(instance, root):
-    config = {"taskdep": {"attrs": {"task": "foo"}}}
-    instance._add_task_dependency(e=root, config=config)
-    dependency = root[0]
-    assert dependency.tag == "dependency"
-    taskdep = dependency[0]
-    assert taskdep.tag == "taskdep"
-    assert taskdep.get("task") == "foo"
-
-
-def test__RocotoXML__add_task_dependency_fail(instance, root):
-    config = {"unrecognized": "whatever"}
-    with raises(UWConfigError):
+    def test__RocotoXML__add_task_dependency(self, instance, root):
+        config = {"taskdep": {"attrs": {"task": "foo"}}}
         instance._add_task_dependency(e=root, config=config)
+        dependency = root[0]
+        assert dependency.tag == "dependency"
+        taskdep = dependency[0]
+        assert taskdep.tag == "taskdep"
+        assert taskdep.get("task") == "foo"
 
+    def test__RocotoXML__add_task_dependency_fail(self, instance, root):
+        config = {"unrecognized": "whatever"}
+        with raises(UWConfigError):
+            instance._add_task_dependency(e=root, config=config)
 
-def test__RocotoXML__add_task_envar(instance, root):
-    instance._add_task_envar(root, "foo", "bar")
-    envar = root[0]
-    name, value = envar
-    assert name.tag == "name"
-    assert name.text == "foo"
-    assert value.tag == "value"
-    assert value.text == "bar"
+    def test__RocotoXML__add_task_envar(self, instance, root):
+        instance._add_task_envar(root, "foo", "bar")
+        envar = root[0]
+        name, value = envar
+        assert name.tag == "name"
+        assert name.text == "foo"
+        assert value.tag == "value"
+        assert value.text == "bar"
 
+    def test__RocotoXML__add_workflow(self, instance):
+        config = {
+            "workflow": {
+                "attrs": {"foo": "1", "bar": "2"},
+                "cycledefs": "3",
+                "log": "4",
+                "tasks": "5",
+            }
+        }
+        with patch.multiple(
+            instance, _add_workflow_cycledefs=D, _add_workflow_log=D, _add_workflow_tasks=D
+        ) as mocks:
+            instance._add_workflow(config=config)
+        workflow = instance._root
+        assert workflow.tag == "workflow"
+        assert workflow.get("foo") == "1"
+        assert workflow.get("bar") == "2"
+        mocks["_add_workflow_cycledefs"].assert_called_once_with(workflow, "3")
+        mocks["_add_workflow_log"].assert_called_once_with(workflow, "4")
+        mocks["_add_workflow_tasks"].assert_called_once_with(workflow, "5")
 
-def test__RocotoXML__add_workflow(instance):
-    config = {
-        "workflow": {"attrs": {"foo": "1", "bar": "2"}, "cycledefs": "3", "log": "4", "tasks": "5"}
-    }
-    with patch.multiple(
-        instance, _add_workflow_cycledefs=D, _add_workflow_log=D, _add_workflow_tasks=D
-    ) as mocks:
-        instance._add_workflow(config=config)
-    workflow = instance._root
-    assert workflow.tag == "workflow"
-    assert workflow.get("foo") == "1"
-    assert workflow.get("bar") == "2"
-    mocks["_add_workflow_cycledefs"].assert_called_once_with(workflow, "3")
-    mocks["_add_workflow_log"].assert_called_once_with(workflow, "4")
-    mocks["_add_workflow_tasks"].assert_called_once_with(workflow, "5")
+    def test__RocotoXML__add_workflow_cycledefs(self, instance, root):
+        config = {"foo": ["1", "2"], "bar": ["3", "4"]}
+        instance._add_workflow_cycledefs(e=root, config=config)
+        for i, group, coord in [(0, "foo", "1"), (1, "foo", "2"), (2, "bar", "3"), (3, "bar", "4")]:
+            assert root[i].tag == "cycledef"
+            assert root[i].get("group") == group
+            assert root[i].text == coord
 
+    def test__RocotoXML__add_workflow_log(self, instance, root):
+        path = "/path/to/logfile"
+        instance._add_workflow_log(e=root, logfile=path)
+        log = root[0]
+        assert log.tag == "log"
+        assert log.text == path
 
-def test__RocotoXML__add_workflow_cycledefs(instance, root):
-    config = {"foo": ["1", "2"], "bar": ["3", "4"]}
-    instance._add_workflow_cycledefs(e=root, config=config)
-    for i, group, coord in [(0, "foo", "1"), (1, "foo", "2"), (2, "bar", "3"), (3, "bar", "4")]:
-        assert root[i].tag == "cycledef"
-        assert root[i].get("group") == group
-        assert root[i].text == coord
+    def test__RocotoXML__add_workflow_tasks(self, instance, root):
+        config = {"metatask_foo": "1", "task_bar": "2"}
+        with patch.multiple(instance, _add_metatask=D, _add_task=D) as mocks:
+            instance._add_workflow_tasks(e=root, config=config)
+        mocks["_add_metatask"].assert_called_once_with(root, "1", "foo")
+        mocks["_add_task"].assert_called_once_with(root, "2", "bar")
 
+    def test__RocotoXML__insert_doctype(self, instance):
+        with patch.object(rocoto._RocotoXML, "_doctype", new_callable=PropertyMock) as _doctype:
+            _doctype.return_value = "bar"
+            assert instance._insert_doctype("foo\nbaz\n") == "foo\nbar\nbaz\n"
 
-def test__RocotoXML__add_workflow_log(instance, root):
-    path = "/path/to/logfile"
-    instance._add_workflow_log(e=root, logfile=path)
-    log = root[0]
-    assert log.tag == "log"
-    assert log.text == path
+    def test__RocotoXML__insert_doctype_none(self, instance):
+        with patch.object(rocoto._RocotoXML, "_doctype", new_callable=PropertyMock) as _doctype:
+            _doctype.return_value = None
+            assert instance._insert_doctype("foo\nbaz\n") == "foo\nbaz\n"
 
+    def test__RocotoXML__set_and_render_jobname(self, instance):
+        config = {"foo": "{{ jobname }}", "baz": "{{ qux }}"}
+        assert instance._set_and_render_jobname(config=config, taskname="bar") == {
+            "jobname": "bar",  # set
+            "foo": "bar",  # rendered
+            "baz": "{{ qux }}",  # ignored
+        }
 
-def test__RocotoXML__add_workflow_tasks(instance, root):
-    config = {"metatask_foo": "1", "task_bar": "2"}
-    with patch.multiple(instance, _add_metatask=D, _add_task=D) as mocks:
-        instance._add_workflow_tasks(e=root, config=config)
-    mocks["_add_metatask"].assert_called_once_with(root, "1", "foo")
-    mocks["_add_task"].assert_called_once_with(root, "2", "bar")
+    def test__RocotoXML__setattrs(self, instance, root):
+        config = {"attrs": {"foo": "1", "bar": "2"}}
+        instance._set_attrs(e=root, config=config)
+        assert root.get("foo") == "1"
+        assert root.get("bar") == "2"
 
-
-def test__RocotoXML__insert_doctype(instance):
-    with patch.object(rocoto._RocotoXML, "_doctype", new_callable=PropertyMock) as _doctype:
-        _doctype.return_value = "bar"
-        assert instance._insert_doctype("foo\nbaz\n") == "foo\nbar\nbaz\n"
-
-
-def test__RocotoXML__insert_doctype_none(instance):
-    with patch.object(rocoto._RocotoXML, "_doctype", new_callable=PropertyMock) as _doctype:
-        _doctype.return_value = None
-        assert instance._insert_doctype("foo\nbaz\n") == "foo\nbaz\n"
-
-
-def test__RocotoXML__set_and_render_jobname(instance):
-    config = {"foo": "{{ jobname }}", "baz": "{{ qux }}"}
-    assert instance._set_and_render_jobname(config=config, taskname="bar") == {
-        "jobname": "bar",  # set
-        "foo": "bar",  # rendered
-        "baz": "{{ qux }}",  # ignored
-    }
-
-
-def test__RocotoXML__setattrs(instance, root):
-    config = {"attrs": {"foo": "1", "bar": "2"}}
-    instance._set_attrs(e=root, config=config)
-    assert root.get("foo") == "1"
-    assert root.get("bar") == "2"
-
-
-def test__RocotoXML__tag_name(instance):
-    assert instance._tag_name("foo") == ("foo", "")
-    assert instance._tag_name("foo_bar") == ("foo", "bar")
-    assert instance._tag_name("foo_bar_baz") == ("foo", "bar_baz")
+    def test__RocotoXML__tag_name(self, instance):
+        assert instance._tag_name("foo") == ("foo", "")
+        assert instance._tag_name("foo_bar") == ("foo", "bar")
+        assert instance._tag_name("foo_bar_baz") == ("foo", "bar_baz")

--- a/src/uwtools/utils/file.py
+++ b/src/uwtools/utils/file.py
@@ -19,7 +19,7 @@ from uwtools.types import DefinitePath, OptionalPath
 
 
 @dataclass(frozen=True)
-class _FORMAT:
+class FORMAT:
     """
     A mapping from config format names to literal strings.
     """
@@ -46,9 +46,6 @@ class _FORMAT:
     sh: str = _ini
     yaml: str = _yaml
     yml: str = _yaml
-
-
-FORMAT = _FORMAT()
 
 
 class StdinProxy:


### PR DESCRIPTION
Three small updates:

1. I realized that it's not necessary to instantiate a `@dataclass` object, at least for our use case: The members of the class itself can be used directly, which leads to a minor simplification.
2. The `README.md` needed a couple of minor changes for accuracy.
3. Following up on a great question from @christinaholtNOAA in my previous PR, I found that it was indeed useful to organize the tests of class `uwtools.rocoto._RocotoXML` into a pytest class.