### PR TITLE
UW-412: expand tests to also not provide optional args

### DIFF
--- a/src/uwtools/cli.py
+++ b/src/uwtools/cli.py
@@ -11,7 +11,7 @@ from argparse import _SubParsersAction as Subparsers
 from dataclasses import dataclass
 from functools import partial
 from pathlib import Path
-from typing import Callable, Dict, List, Tuple
+from typing import Callable, Dict, List, Optional, Tuple
 
 import uwtools.config.atparse_to_jinja2
 import uwtools.config.core
@@ -726,14 +726,14 @@ def _check_template_render_vals_args(args: Namespace) -> Namespace:
     return args
 
 
-def _dict_from_key_eq_val_strings(config_items: List[str]) -> Dict[str, str]:
+def _dict_from_key_eq_val_strings(config_items: Optional[List[str]] = None) -> Dict[str, str]:
     """
     Given a list of key=value strings, return a dictionary of key/value pairs.
 
     :param config_items: Strings in the form key=value.
     :return: A dictionary based on the input key=value strings.
     """
-    return dict([arg.split("=") for arg in config_items])
+    return dict([arg.split("=") for arg in config_items]) if config_items else {}
 
 
 def _formatter(prog: str) -> HelpFormatter:

--- a/src/uwtools/cli.py
+++ b/src/uwtools/cli.py
@@ -11,7 +11,7 @@ from argparse import _SubParsersAction as Subparsers
 from dataclasses import dataclass
 from functools import partial
 from pathlib import Path
-from typing import Callable, Dict, List, Optional, Tuple
+from typing import Callable, Dict, List, Tuple
 
 import uwtools.config.atparse_to_jinja2
 import uwtools.config.core
@@ -726,14 +726,14 @@ def _check_template_render_vals_args(args: Namespace) -> Namespace:
     return args
 
 
-def _dict_from_key_eq_val_strings(config_items: Optional[List[str]] = None) -> Dict[str, str]:
+def _dict_from_key_eq_val_strings(config_items: List[str]) -> Dict[str, str]:
     """
     Given a list of key=value strings, return a dictionary of key/value pairs.
 
     :param config_items: Strings in the form key=value.
     :return: A dictionary based on the input key=value strings.
     """
-    return dict([arg.split("=") for arg in config_items]) if config_items else {}
+    return dict([arg.split("=") for arg in config_items])
 
 
 def _formatter(prog: str) -> HelpFormatter:

--- a/src/uwtools/tests/test_cli.py
+++ b/src/uwtools/tests/test_cli.py
@@ -388,9 +388,9 @@ def test__dispatch_template(params):
 
 def test__dispatch_template_render_no_optional():
     args, _ = cli._parse_args("uw template render".split()[1:])
-    with patch.object(cli.uwtools.config.templater, STR.render) as templater:
+    with patch.object(cli.uwtools.config.templater, "render") as render:
         cli._dispatch_template_render(args)
-    assert templater.called_once_with(args)
+    assert render.called_once_with(args)
 
 
 def test__dispatch_template_render_yaml():
@@ -406,9 +406,9 @@ def test__dispatch_template_render_yaml():
             STR.dryrun: 7,
         }
     )
-    with patch.object(cli.uwtools.config.templater, STR.render) as templater:
+    with patch.object(cli.uwtools.config.templater, "render") as render:
         cli._dispatch_template_render(args)
-    assert templater.called_once_with(args)
+    assert render.called_once_with(args)
 
 
 @pytest.mark.parametrize("quiet", [True])

--- a/src/uwtools/tests/test_cli.py
+++ b/src/uwtools/tests/test_cli.py
@@ -226,19 +226,7 @@ def test__dispatch_config_realize():
 
 
 def test__dispatch_config_realize_no_optional():
-    args = ns()
-    vars(args).update(
-        {
-            STR.infile: None,
-            STR.infmt: None,
-            STR.outfile: None,
-            STR.outfmt: None,
-            STR.valsfile: 5,
-            STR.valsfmt: None,
-            STR.valsneeded: None,
-            STR.dryrun: None,
-        }
-    )
+    args, _ = cli._parse_args("uw config realize --values-file /foo.vals".split()[1:])
     with patch.object(cli.uwtools.config.core, "realize_config") as realize_config:
         cli._dispatch_config_realize(args)
     assert realize_config.called_once_with(args)
@@ -261,16 +249,7 @@ def test__dispatch_config_translate_atparse_to_jinja2():
 
 
 def test__dispatch_config_translate_no_optional():
-    args = ns()
-    vars(args).update(
-        {
-            STR.infile: None,
-            STR.infmt: None,
-            STR.outfile: None,
-            STR.outfmt: None,
-            STR.dryrun: None,
-        }
-    )
+    args, _ = cli._parse_args("uw config translate".split()[1:])
     with patch.object(cli.uwtools.config.atparse_to_jinja2, "convert") as convert:
         cli._dispatch_config_translate(args)
     assert convert.called_once_with(args)
@@ -285,8 +264,7 @@ def test__dispatch_config_translate_unsupported():
 
 
 def test__dispatch_config_validate_no_optional():
-    args = ns()
-    vars(args).update({STR.infile: None, STR.infmt: None, STR.schemafile: 3})
+    args, _ = cli._parse_args("uw config validate --schema-file /foo.schema".split()[1:])
     with patch.object(cli.uwtools.config.validator, "validate_yaml") as validate_yaml:
         cli._dispatch_config_validate(args)
     assert validate_yaml.called_once_with(args)
@@ -370,8 +348,7 @@ def test__dispatch_rocoto_realize_invalid():
 
 
 def test__dispatch_rocoto_realize_no_optional():
-    args = ns()
-    vars(args).update({STR.infile: None, STR.outfile: None})
+    args, _ = cli._parse_args("uw rocoto realize".split()[1:])
     with patch.object(cli.uwtools.rocoto, "realize_rocoto_xml") as module:
         cli._dispatch_rocoto_realize(args)
     assert module.called_once_with(args)
@@ -393,8 +370,7 @@ def test__dispatch_rocoto_validate_xml_invalid():
 
 
 def test__dispatch_rocoto_validate_xml_no_optional():
-    args = ns()
-    vars(args).update({STR.infile: None})
+    args, _ = cli._parse_args("uw rocoto validate".split()[1:])
     with patch.object(cli.uwtools.rocoto, "validate_rocoto_xml") as validate:
         cli._dispatch_rocoto_validate(args)
     assert validate.called_once_with(args)
@@ -411,18 +387,7 @@ def test__dispatch_template(params):
 
 
 def test__dispatch_template_render_no_optional():
-    args = ns()
-    vars(args).update(
-        {
-            STR.infile: None,
-            STR.outfile: None,
-            STR.valsfile: None,
-            STR.valsfmt: None,
-            STR.keyvalpairs: None,
-            STR.valsneeded: None,
-            STR.dryrun: None,
-        }
-    )
+    args, _ = cli._parse_args("uw template render".split()[1:])
     with patch.object(cli.uwtools.config.templater, STR.render) as templater:
         cli._dispatch_template_render(args)
     assert templater.called_once_with(args)

--- a/src/uwtools/tests/test_cli.py
+++ b/src/uwtools/tests/test_cli.py
@@ -389,12 +389,12 @@ def test__dispatch_template(params):
 
 
 def test__dispatch_template_render_no_optional():
-    args = {
+    args: dict = {
         STR.infile: None,
         STR.outfile: None,
         STR.valsfile: None,
         STR.valsfmt: None,
-        STR.keyvalpairs: "",
+        STR.keyvalpairs: [],
         STR.valsneeded: False,
         STR.dryrun: False,
     }

--- a/src/uwtools/tests/test_cli.py
+++ b/src/uwtools/tests/test_cli.py
@@ -254,7 +254,13 @@ def test__dispatch_config_translate_atparse_to_jinja2():
 
 
 def test__dispatch_config_translate_no_optional():
-    args, _ = cli._parse_args("uw config translate".split()[1:])
+    args = {
+        STR.dryrun: False,
+        STR.infile: None,
+        STR.infmt: FORMAT.atparse,
+        STR.outfile: None,
+        STR.outfmt: FORMAT.jinja2,
+    }
     with patch.object(cli.uwtools.config.atparse_to_jinja2, "convert") as convert:
         cli._dispatch_config_translate(args)
     convert.assert_called_once_with(input_file=None, output_file=None, dry_run=False)
@@ -266,7 +272,7 @@ def test__dispatch_config_translate_unsupported():
 
 
 def test__dispatch_config_validate_no_optional():
-    args, _ = cli._parse_args("uw config validate --schema-file /foo.schema".split()[1:])
+    args = {STR.infile: None, STR.infmt: FORMAT.yaml, STR.schemafile: "/foo.schema"}
     with patch.object(cli.uwtools.config.validator, "validate_yaml") as validate_yaml:
         cli._dispatch_config_validate(args)
     validate_yaml.assert_called_once_with(config_file=None, schema_file="/foo.schema")

--- a/src/uwtools/tests/test_cli.py
+++ b/src/uwtools/tests/test_cli.py
@@ -225,7 +225,16 @@ def test__dispatch_config_realize():
 
 
 def test__dispatch_config_realize_no_optional():
-    args, _ = cli._parse_args("uw config realize --values-file /foo.vals".split()[1:])
+    args = {
+        STR.infile: None,
+        STR.infmt: None,
+        STR.outfile: None,
+        STR.outfmt: None,
+        STR.valsfile: "/foo.vals",
+        STR.valsfmt: None,
+        STR.valsneeded: False,
+        STR.dryrun: False,
+    }
     with patch.object(cli.uwtools.config.core, "realize_config") as realize_config:
         cli._dispatch_config_realize(args)
     realize_config.assert_called_once_with(
@@ -344,7 +353,7 @@ def test__dispatch_rocoto_realize_invalid():
 
 
 def test__dispatch_rocoto_realize_no_optional():
-    args, _ = cli._parse_args("uw rocoto realize".split()[1:])
+    args = {STR.infile: None, STR.outfile: None}
     with patch.object(cli.uwtools.rocoto, "realize_rocoto_xml") as module:
         cli._dispatch_rocoto_realize(args)
     module.assert_called_once_with(config_file=None, output_file=None)
@@ -364,7 +373,7 @@ def test__dispatch_rocoto_validate_xml_invalid():
 
 
 def test__dispatch_rocoto_validate_xml_no_optional():
-    args, _ = cli._parse_args("uw rocoto validate".split()[1:])
+    args = {STR.infile: None, STR.verbose: False}
     with patch.object(cli.uwtools.rocoto, "validate_rocoto_xml") as validate:
         cli._dispatch_rocoto_validate(args)
     validate.assert_called_once_with(input_xml=None)
@@ -380,7 +389,15 @@ def test__dispatch_template(params):
 
 
 def test__dispatch_template_render_no_optional():
-    args, _ = cli._parse_args("uw template render".split()[1:])
+    args = {
+        STR.infile: None,
+        STR.outfile: None,
+        STR.valsfile: None,
+        STR.valsfmt: None,
+        STR.keyvalpairs: "",
+        STR.valsneeded: False,
+        STR.dryrun: False,
+    }
     with patch.object(cli.uwtools.config.templater, "render") as render:
         cli._dispatch_template_render(args)
     render.assert_called_once_with(

--- a/src/uwtools/tests/test_cli.py
+++ b/src/uwtools/tests/test_cli.py
@@ -225,7 +225,26 @@ def test__dispatch_config_realize():
     assert realize_config.called_once_with(args)
 
 
-def test__dispatch_config_translate_arparse_to_jinja2():
+def test__dispatch_config_realize_no_optional():
+    args = ns()
+    vars(args).update(
+        {
+            STR.infile: None,
+            STR.infmt: None,
+            STR.outfile: None,
+            STR.outfmt: None,
+            STR.valsfile: 5,
+            STR.valsfmt: None,
+            STR.valsneeded: None,
+            STR.dryrun: None,
+        }
+    )
+    with patch.object(cli.uwtools.config.core, "realize_config") as realize_config:
+        cli._dispatch_config_realize(args)
+    assert realize_config.called_once_with(args)
+
+
+def test__dispatch_config_translate_atparse_to_jinja2():
     args = ns()
     vars(args).update(
         {
@@ -241,6 +260,22 @@ def test__dispatch_config_translate_arparse_to_jinja2():
     assert convert.called_once_with(args)
 
 
+def test__dispatch_config_translate_no_optional():
+    args = ns()
+    vars(args).update(
+        {
+            STR.infile: None,
+            STR.infmt: None,
+            STR.outfile: None,
+            STR.outfmt: None,
+            STR.dryrun: None,
+        }
+    )
+    with patch.object(cli.uwtools.config.atparse_to_jinja2, "convert") as convert:
+        cli._dispatch_config_translate(args)
+    assert convert.called_once_with(args)
+
+
 def test__dispatch_config_translate_unsupported():
     args = ns()
     vars(args).update(
@@ -249,9 +284,9 @@ def test__dispatch_config_translate_unsupported():
     assert cli._dispatch_config_translate(args) is False
 
 
-def test__dispatch_config_validate_yaml():
+def test__dispatch_config_validate_no_optional():
     args = ns()
-    vars(args).update({STR.infile: 1, STR.infmt: FORMAT.yaml, STR.schemafile: 3})
+    vars(args).update({STR.infile: None, STR.infmt: None, STR.schemafile: 3})
     with patch.object(cli.uwtools.config.validator, "validate_yaml") as validate_yaml:
         cli._dispatch_config_validate(args)
     assert validate_yaml.called_once_with(args)
@@ -261,6 +296,14 @@ def test__dispatch_config_validate_unsupported():
     args = ns()
     vars(args).update({STR.infile: 1, STR.infmt: "jpg", STR.schemafile: 3})
     assert cli._dispatch_config_validate(args) is False
+
+
+def test__dispatch_config_validate_yaml():
+    args = ns()
+    vars(args).update({STR.infile: 1, STR.infmt: FORMAT.yaml, STR.schemafile: 3})
+    with patch.object(cli.uwtools.config.validator, "validate_yaml") as validate_yaml:
+        cli._dispatch_config_validate(args)
+    assert validate_yaml.called_once_with(args)
 
 
 @pytest.mark.parametrize("params", [(STR.run, "_dispatch_forecast_run")])
@@ -326,6 +369,14 @@ def test__dispatch_rocoto_realize_invalid():
         assert cli._dispatch_rocoto_realize(args) is False
 
 
+def test__dispatch_rocoto_realize_no_optional():
+    args = ns()
+    vars(args).update({STR.infile: None, STR.outfile: None})
+    with patch.object(cli.uwtools.rocoto, "realize_rocoto_xml") as module:
+        cli._dispatch_rocoto_realize(args)
+    assert module.called_once_with(args)
+
+
 def test__dispatch_rocoto_validate_xml():
     args = ns()
     vars(args).update({STR.infile: 1})
@@ -341,6 +392,14 @@ def test__dispatch_rocoto_validate_xml_invalid():
         assert cli._dispatch_rocoto_validate(args) is False
 
 
+def test__dispatch_rocoto_validate_xml_no_optional():
+    args = ns()
+    vars(args).update({STR.infile: None})
+    with patch.object(cli.uwtools.rocoto, "validate_rocoto_xml") as validate:
+        cli._dispatch_rocoto_validate(args)
+    assert validate.called_once_with(args)
+
+
 @pytest.mark.parametrize("params", [(STR.render, "_dispatch_template_render")])
 def test__dispatch_template(params):
     submode, funcname = params
@@ -349,6 +408,24 @@ def test__dispatch_template(params):
     with patch.object(cli, funcname) as func:
         cli._dispatch_template(args)
     assert func.called_once_with(args)
+
+
+def test__dispatch_template_render_no_optional():
+    args = ns()
+    vars(args).update(
+        {
+            STR.infile: None,
+            STR.outfile: None,
+            STR.valsfile: None,
+            STR.valsfmt: None,
+            STR.keyvalpairs: None,
+            STR.valsneeded: None,
+            STR.dryrun: None,
+        }
+    )
+    with patch.object(cli.uwtools.config.templater, STR.render) as templater:
+        cli._dispatch_template_render(args)
+    assert templater.called_once_with(args)
 
 
 def test__dispatch_template_render_yaml():

--- a/src/uwtools/tests/test_cli.py
+++ b/src/uwtools/tests/test_cli.py
@@ -228,7 +228,17 @@ def test__dispatch_config_realize_no_optional():
     args, _ = cli._parse_args("uw config realize --values-file /foo.vals".split()[1:])
     with patch.object(cli.uwtools.config.core, "realize_config") as realize_config:
         cli._dispatch_config_realize(args)
-    realize_config.assert_called_once_with(args)
+    realize_config.assert_called_once_with(
+        input_file=None,
+        input_format=None,
+        output_file=None,
+        output_format=None,
+        values_file="/foo.vals",
+        values_format=None,
+        values_needed=False,
+        dry_run=False,
+    )
+
 
 def test__dispatch_config_translate_atparse_to_jinja2():
     args = {
@@ -247,7 +257,7 @@ def test__dispatch_config_translate_no_optional():
     args, _ = cli._parse_args("uw config translate".split()[1:])
     with patch.object(cli.uwtools.config.atparse_to_jinja2, "convert") as convert:
         cli._dispatch_config_translate(args)
-    assert convert.called_once_with(args)
+    convert.assert_called_once_with(input_file=None, output_file=None, dry_run=False)
 
 
 def test__dispatch_config_translate_unsupported():
@@ -259,7 +269,7 @@ def test__dispatch_config_validate_no_optional():
     args, _ = cli._parse_args("uw config validate --schema-file /foo.schema".split()[1:])
     with patch.object(cli.uwtools.config.validator, "validate_yaml") as validate_yaml:
         cli._dispatch_config_validate(args)
-    validate_yaml.assert_called_once_with(args)
+    validate_yaml.assert_called_once_with(config_file=None, schema_file="/foo.schema")
 
 
 def test__dispatch_config_validate_unsupported():
@@ -331,7 +341,7 @@ def test__dispatch_rocoto_realize_no_optional():
     args, _ = cli._parse_args("uw rocoto realize".split()[1:])
     with patch.object(cli.uwtools.rocoto, "realize_rocoto_xml") as module:
         cli._dispatch_rocoto_realize(args)
-    assert module.called_once_with(args)
+    module.assert_called_once_with(config_file=None, output_file=None)
 
 
 def test__dispatch_rocoto_validate_xml():
@@ -351,7 +361,7 @@ def test__dispatch_rocoto_validate_xml_no_optional():
     args, _ = cli._parse_args("uw rocoto validate".split()[1:])
     with patch.object(cli.uwtools.rocoto, "validate_rocoto_xml") as validate:
         cli._dispatch_rocoto_validate(args)
-    assert validate.called_once_with(args)
+    validate.assert_called_once_with(input_xml=None)
 
 
 @pytest.mark.parametrize("params", [(STR.render, "_dispatch_template_render")])
@@ -367,7 +377,15 @@ def test__dispatch_template_render_no_optional():
     args, _ = cli._parse_args("uw template render".split()[1:])
     with patch.object(cli.uwtools.config.templater, "render") as render:
         cli._dispatch_template_render(args)
-    assert render.called_once_with(args)
+    render.assert_called_once_with(
+        input_file=None,
+        output_file=None,
+        values_file=None,
+        values_format=None,
+        overrides={},
+        values_needed=False,
+        dry_run=False,
+    )
 
 
 def test__dispatch_template_render_yaml():


### PR DESCRIPTION
**Description**
Tests demonstrate that argparse doesn't complain and that, eg. args.input_file is None

Fixes issue #329 

**Type of change**
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**
- [x] pytests in GitHub actions.
- [ ] Tests on Ubuntu OS

**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes need updates to the documentation.  I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [x] Any dependent changes have been merged and published

<!-- 
 If there is a co-author attribution:

Update the final commit message (when squashing and merging) to include  `Co-authored-by: name <name@example.com>` (e.g. `Co-authored-by: Jane Doe <jane_doe@example.com>`).  Each co-author must have their own line, and the email address used must be the email address connected with their GitHub account.
-->
