### PR TITLE
UW-371: refactor of render() 

### DIFF
--- a/src/uwtools/config/jinja2.py
+++ b/src/uwtools/config/jinja2.py
@@ -201,11 +201,11 @@ def render(
     if missing:
         return _log_missing_values(missing)
 
-    # In dry-run mode, log the rendered template. Otherwisre, write rendered template to file.
+    # In dry-run mode, log the rendered template. Otherwise, write rendered template to file.
     return (
         _dry_run_template(template.render())
         if dry_run
-        else _write_template_to_file(output_file, template.render())
+        else _write_template(output_file, template.render())
     )
 
 
@@ -231,7 +231,7 @@ def _log_missing_values(missing: List[str]) -> bool:
 
     :param missing: A list containing the undeclared variables that do not have a corresponding
         match in values.
-    :return: Unable to sucessfully render template.
+    :return: Unable to successfully render template.
     """
 
     log.error("Required value(s) not provided:")
@@ -331,13 +331,13 @@ def _values_needed(undeclared_variables: Set[str]) -> bool:
     return True
 
 
-def _write_template_to_file(output_file: OptionalPath, rendered_template: str) -> bool:
+def _write_template(output_file: OptionalPath, rendered_template: str) -> bool:
     """
-    Write the rendered template to file.
+    Write the rendered template.
 
     :param output_file: Path to the file to write the rendered Jinja2 template to.
     :param rendered_template: A string containing a rendered Jinja2 template.
-    :return: The successful writing of the rendered template to the outfile.
+    :return: The successful writing of the rendered template.
     """
     with writable(output_file) as f:
         print(rendered_template, file=f)

--- a/src/uwtools/config/jinja2.py
+++ b/src/uwtools/config/jinja2.py
@@ -175,6 +175,9 @@ def render(
     :param values_needed: Just issue a report about variables needed to render the template?
     :param dry_run: Run in dry-run mode?
     """
+
+    # Render template.
+
     _report(locals())
     values = _set_up_values_obj(
         values_file=values_file, values_format=values_format, overrides=overrides
@@ -188,38 +191,52 @@ def render(
     # then return.
 
     if values_needed:
-        log.info("Value(s) needed to render this template are:")
-        for var in sorted(undeclared_variables):
-            log.info(var)
-        return True
+        return _values_needed(undeclared_variables)
 
     # Check for missing values required to render the template. If found, report them and raise an
     # exception.
 
     missing = [var for var in undeclared_variables if var not in values.keys()]
     if missing:
-        msg = "Required value(s) not provided:"
-        log.error(msg)
-        for key in missing:
-            log.error(key)
-        return False
+        return _log_missing_values(missing)
 
-    # In dry-run mode, display the rendered template and then return.
-
-    if dry_run:
-        rendered_template = template.render()
-        for line in rendered_template.split("\n"):
-            log.info(line)
-        return True
-
-    # Write rendered template to file.
-
-    with writable(output_file) as f:
-        print(template.render(), file=f)
-    return True
+    # In dry-run mode, log the rendered template. Otherwisre, write rendered template to file.
+    return (
+        _dry_run_template(template.render())
+        if dry_run
+        else _write_template_to_file(output_file, template.render())
+    )
 
 
 # Private functions
+
+
+def _dry_run_template(rendered_template: str) -> bool:
+    """
+    Log the rendered template and then return as successful.
+
+    :param rendered_template: A string containing a rendered Jinja2 template.
+    :return: The successful logging of the template.
+    """
+
+    for line in rendered_template.split("\n"):
+        log.info(line)
+    return True
+
+
+def _log_missing_values(missing: List[str]) -> bool:
+    """
+    Log values missing from template and raise an exception.
+
+    :param missing: A list containing the undeclared variables that do not have a corresponding
+        match in values.
+    :return: Unable to sucessfully render template.
+    """
+
+    log.error("Required value(s) not provided:")
+    for key in missing:
+        log.error(key)
+    return False
 
 
 def _register_filters(env: Environment) -> Environment:
@@ -295,3 +312,32 @@ def _set_up_values_obj(
         values.update(overrides)
         log.debug("Updated values with overrides: %s", " ".join(overrides))
     return values
+
+
+def _values_needed(undeclared_variables: Set[str]) -> bool:
+    """
+    Log variables needed to render the template.
+
+    :param undeclared_variables: A set containing the variables needed to render the template.
+    :return: Successfully logged values needed.
+    """
+
+    # If a report of variables required to render the template was requested, make that report and
+    # then return.
+    log.info("Value(s) needed to render this template are:")
+    for var in sorted(undeclared_variables):
+        log.info(var)
+    return True
+
+
+def _write_template_to_file(output_file: OptionalPath, rendered_template: str) -> bool:
+    """
+    Write the rendered template to file.
+
+    :param output_file: Path to the file to write the rendered Jinja2 template to.
+    :param rendered_template: A string containing a rendered Jinja2 template.
+    :return: The successful writing of the rendered template to the outfile.
+    """
+    with writable(output_file) as f:
+        print(rendered_template, file=f)
+    return True

--- a/src/uwtools/config/jinja2.py
+++ b/src/uwtools/config/jinja2.py
@@ -201,7 +201,8 @@ def render(
     if missing:
         return _log_missing_values(missing)
 
-    # In dry-run mode, log the rendered template. Otherwise, write rendered template to file.
+    # In dry-run mode, log the rendered template. Otherwise, write the rendered template.
+
     return (
         _dry_run_template(template.render())
         if dry_run

--- a/src/uwtools/config/jinja2.py
+++ b/src/uwtools/config/jinja2.py
@@ -166,7 +166,7 @@ def render(
     dry_run: bool = False,
 ) -> bool:
     """
-    Render a Jinja2 template.
+    Check and render a Jinja2 template.
 
     :param input_file: Path to the Jinja2 template file to render.
     :param output_file: Path to the file to write the rendered Jinja2 template to.
@@ -174,6 +174,7 @@ def render(
     :param keq_eq_val_pairs: "key=value" strings to supplement values-file values.
     :param values_needed: Just issue a report about variables needed to render the template?
     :param dry_run: Run in dry-run mode?
+    :return: Jinja2 template was successfully rendered.
     """
 
     # Render template.

--- a/src/uwtools/drivers/driver.py
+++ b/src/uwtools/drivers/driver.py
@@ -94,7 +94,7 @@ class Driver(ABC):
     @property
     def scheduler(self) -> JobScheduler:
         """
-        The job scheduler speficied by the platform information.
+        The job scheduler specified by the platform information.
 
         :return: The scheduler object
         """

--- a/src/uwtools/drivers/forecast.py
+++ b/src/uwtools/drivers/forecast.py
@@ -199,7 +199,7 @@ class FV3Forecast(Driver):
     def _boundary_hours(self, lbcs_config: Dict) -> tuple[int, int, int]:
         """
         Prepares parameters to generate the lateral boundary condition (LBCS) forecast hours from an
-        external intput data source, e.g. GFS, RAP, etc.
+        external input data source, e.g. GFS, RAP, etc.
 
         :return: The offset hours between the cycle and the external input data, the hours between
             LBC ingest, and the last hour of the external input data forecast

--- a/src/uwtools/tests/config/test_jinja2.py
+++ b/src/uwtools/tests/config/test_jinja2.py
@@ -316,8 +316,7 @@ def test__write_template_to_file(tmp_path):
 
 
 def test__write_template_stdout(capsys):
-    outfile = None
-    jinja2._write_template(outfile, "roses are red, violets are blue")
+    jinja2._write_template(None, "roses are red, violets are blue")
     actual = capsys.readouterr().out
     expected = "roses are red, violets are blue"
     assert actual.strip() == expected

--- a/src/uwtools/tests/config/test_jinja2.py
+++ b/src/uwtools/tests/config/test_jinja2.py
@@ -222,7 +222,7 @@ def test_render_calls__values_needed(template, tmp_path, values_file):
 
 def test_render_calls__write(template, tmp_path, values_file):
     outfile = str(tmp_path / "out.txt")
-    with patch.object(jinja2, "_write_template_to_file") as write:
+    with patch.object(jinja2, "_write_template") as write:
         render_helper(input_file=template, values_file=values_file, output_file=outfile)
         write.assert_called_once_with(outfile, "roses are red, violets are blue")
 
@@ -258,8 +258,9 @@ def test_render_values_needed(caplog, template, values_file):
 
 
 def test__dry_run_template(caplog):
-    jinja2._dry_run_template("roses are red, violets are blue")
-    assert logged(caplog, "roses are red, violets are blue")
+    jinja2._dry_run_template("roses are red\nviolets are blue")
+    assert logged(caplog, "roses are red")
+    assert logged(caplog, "violets are blue")
 
 
 def test__log_missing_values(caplog):
@@ -309,9 +310,17 @@ def test__values_needed(caplog):
 
 def test__write_template_to_file(tmp_path):
     outfile = str(tmp_path / "out.txt")
-    jinja2._write_template_to_file(outfile, "roses are red, violets are blue")
+    jinja2._write_template(outfile, "roses are red, violets are blue")
     with open(outfile, "r", encoding="utf-8") as f:
         assert f.read().strip() == "roses are red, violets are blue"
+
+
+def test__write_template_stdout(capsys):
+    outfile = None
+    jinja2._write_template(outfile, "roses are red, violets are blue")
+    actual = capsys.readouterr().out
+    expected = "roses are red, violets are blue"
+    assert actual.strip() == expected
 
 
 class Test_Jinja2Template:


### PR DESCRIPTION
<!--

INSTRUCTIONS

- Please do not commit temporary, backup, or binary files.
- Please remove commented-out code.
- Please ensure code, config files, etc., contain no hardcoded paths.
- Please format code snippets in PR description/comments with ```code block``` or `inline code`.
- Please consider adding your own review comments to guide other reviewers.

-->

**Description**

<!-- A summary of the change, including relevant motivation, context, useful links, etc. -->

`uwtools.config.jinja2.render()` needed a refactor, so I created four helper functions to share its responsibilities. I also created 8 new unit tests: 4 are for the helper functions themselves and the other 4 are to make sure that `render()` is calling those functions. 

I'll add review comments for questions I have.

**Type**

Select one or more:

- [ ] Bug fix (corrects a known issue)
- [x] Code maintenance (refactoring, etc. without behavior change)
- [ ] Documentation
- [ ] Enhancement (adds a new functionality)
- [ ] Tooling (CI, code-quality, packaging, revision-control, etc.)

**Impact**

Select one:

- [x] This is a non-breaking change (existing functionality continues to work as expected)
- [ ] This is a breaking change (changes existing functionality)

**Checklist**

Affirm:

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
