### PR TITLE
UW-418: Split .ini & .sh handling

### DIFF
--- a/docs/Users_Guide/working_with_config.rst
+++ b/docs/Users_Guide/working_with_config.rst
@@ -173,7 +173,7 @@ Conversion flags
     --config-file-type
     --outfile-file-type
 
-``--input-file-type`` and ``--config-file-type`` accept YAML ('YAML'), bash/ini ('INI'), or namelist ('NML') file types; ``--outfile-file-type`` accepts these three as well as field table ('FieldTable').  This tool requires that the given file (input, config, or outfile) have a compatible structure with the provided file type.  A YAML file can have any depth, a bash/ini file can have a depth of 1 or 2, and a namelist file must have a depth of 2.
+``--input-file-type`` and ``--config-file-type`` accept YAML ('YAML'), bash ('SH'), ini ('INI'), or namelist ('NML') file types; ``--outfile-file-type`` accepts these three as well as field table ('FieldTable').  This tool requires that the given file (input, config, or outfile) have a compatible structure with the provided file type.  A YAML file can have any depth, an ini or namelist file must have a depth of 2, and an sh file can only have a depth of 1.
 
 .. _conf_compare:
 

--- a/src/uwtools/cli.py
+++ b/src/uwtools/cli.py
@@ -22,7 +22,7 @@ import uwtools.rocoto
 from uwtools.logging import log, setup_logging
 from uwtools.utils.file import FORMAT, get_file_type
 
-FORMATS = [FORMAT.ini, FORMAT.nml, FORMAT.yaml]
+FORMATS = [FORMAT.ini, FORMAT.nml, FORMAT.sh, FORMAT.yaml]
 TITLE_REQ_ARG = "Required arguments"
 
 Args = Dict[str, Any]

--- a/src/uwtools/config/formats/base.py
+++ b/src/uwtools/config/formats/base.py
@@ -6,7 +6,6 @@ import re
 from abc import ABC, abstractmethod
 from collections import UserDict
 from copy import deepcopy
-from types import SimpleNamespace as ns
 from typing import List, Optional, Tuple, Union
 
 import yaml
@@ -174,13 +173,12 @@ class Config(ABC, UserDict):
 
     @staticmethod
     @abstractmethod
-    def dump_dict(path: OptionalPath, cfg: dict, opts: Optional[ns] = None) -> None:
+    def dump_dict(path: OptionalPath, cfg: dict) -> None:
         """
         Dumps a provided config dictionary to stdout or a file.
 
         :param path: Path to dump config to.
         :param cfg: The in-memory config object to dump.
-        :param opts: Other options required by a subclass.
         """
 
     def parse_include(self, ref_dict: Optional[dict] = None) -> None:

--- a/src/uwtools/config/formats/fieldtable.py
+++ b/src/uwtools/config/formats/fieldtable.py
@@ -8,6 +8,7 @@ class FieldTableConfig(YAMLConfig):
     an input YAML file.
     """
 
+    DEPTH = None
     # Public methods
 
     def dump(self, path: OptionalPath) -> None:
@@ -16,7 +17,7 @@ class FieldTableConfig(YAMLConfig):
 
         :param path: Path to dump config to.
         """
-        FieldTableConfig.dump_dict(path, self.data)
+        self.dump_dict(path, self.data)
 
     @staticmethod
     def dump_dict(path: OptionalPath, cfg: dict) -> None:

--- a/src/uwtools/config/formats/fieldtable.py
+++ b/src/uwtools/config/formats/fieldtable.py
@@ -1,6 +1,3 @@
-from types import SimpleNamespace as ns
-from typing import Optional
-
 from uwtools.config.formats.yaml import YAMLConfig
 from uwtools.utils.file import OptionalPath, writable
 
@@ -22,7 +19,7 @@ class FieldTableConfig(YAMLConfig):
         FieldTableConfig.dump_dict(path, self.data)
 
     @staticmethod
-    def dump_dict(path: OptionalPath, cfg: dict, opts: Optional[ns] = None) -> None:
+    def dump_dict(path: OptionalPath, cfg: dict) -> None:
         """
         Dumps a provided config dictionary in Field Table format.
 

--- a/src/uwtools/config/formats/ini.py
+++ b/src/uwtools/config/formats/ini.py
@@ -1,4 +1,4 @@
-# pylint: disable=duplicate-code, unnecessary-comprehension
+# pylint: disable=duplicate-code
 import configparser
 from io import StringIO
 
@@ -38,7 +38,7 @@ class INIConfig(Config):
         cfg = configparser.ConfigParser()
         with readable(config_file) as f:
             cfg.read_string(f.read())
-        return {s: {k: v for k, v in cfg[s].items()} for s in cfg.sections()}
+        return {s: dict(cfg[s].items()) for s in cfg.sections()}
 
     # Public methods
 

--- a/src/uwtools/config/formats/ini.py
+++ b/src/uwtools/config/formats/ini.py
@@ -3,7 +3,7 @@ import configparser
 from io import StringIO
 
 from uwtools.config.formats.base import Config
-from uwtools.config.support import config_sections, depth
+from uwtools.config.support import config_sections
 from uwtools.utils.file import OptionalPath, readable, writable
 
 

--- a/src/uwtools/config/formats/ini.py
+++ b/src/uwtools/config/formats/ini.py
@@ -81,7 +81,7 @@ class INIConfig(Config):
         parser = configparser.ConfigParser()
         s = StringIO()
         cfgdepth = depth(cfg)
-        assert cfgdepth == 2  # 2 => .ini
+        assert cfgdepth in (1, 2)  # 2 => .ini
         parser.read_dict(cfg)
         parser.write(s, space_around_delimiters=opts.space if opts else True)
         with writable(path) as f:

--- a/src/uwtools/config/formats/ini.py
+++ b/src/uwtools/config/formats/ini.py
@@ -1,10 +1,11 @@
+# pylint: disable=duplicate-code
 import configparser
 from io import StringIO
 from types import SimpleNamespace as ns
 from typing import Optional
 
 from uwtools.config.formats.base import Config
-from uwtools.config.support import depth
+from uwtools.config.support import config_sections, depth
 from uwtools.utils.file import OptionalPath, readable, writable
 
 
@@ -13,10 +14,11 @@ class INIConfig(Config):
     Concrete class to handle INI config files.
     """
 
+    _MAXDEPTH = 2
+
     def __init__(
         self,
         config_file: str,
-        space_around_delimiters: bool = True,
     ):
         """
         Construct an INIConfig object.
@@ -24,10 +26,8 @@ class INIConfig(Config):
         Spaces may be included for INI format, but should be excluded for bash.
 
         :param config_file: Path to the config file to load.
-        :param space_around_delimiters: Include spaces around delimiters?
         """
         super().__init__(config_file)
-        self.space_around_delimiters = space_around_delimiters
         self.parse_include()
 
     # Private methods
@@ -40,20 +40,12 @@ class INIConfig(Config):
 
         :param config_file: Path to config file to load.
         """
-        # The protected _sections method is the most straightforward way to get at the dict
-        # representation of the parse config.
-
         cfg = configparser.ConfigParser()
-        cfg.optionxform = str  # type: ignore
-        sections = cfg._sections  # type: ignore # pylint: disable=protected-access
+        sections = config_sections(cfg)
         with readable(config_file) as f:
             raw = f.read()
-        try:
             cfg.read_string(raw)
-            return dict(sections)
-        except configparser.MissingSectionHeaderError:
-            cfg.read_string("[top]\n" + raw)
-            return dict(sections.get("top"))
+            return sections
 
     # Public methods
 
@@ -63,10 +55,10 @@ class INIConfig(Config):
 
         :param path: Path to dump config to.
         """
-        INIConfig.dump_dict(path, self.data, ns(space=self.space_around_delimiters))
+        INIConfig.dump_dict(path, self.data, space=True)
 
     @staticmethod
-    def dump_dict(path: OptionalPath, cfg: dict, opts: Optional[ns] = None) -> None:
+    def dump_dict(path: OptionalPath, cfg: dict, opts: Optional[ns] = None, **kwargs) -> None:
         """
         Dumps a provided config dictionary in INI format.
 
@@ -78,12 +70,12 @@ class INIConfig(Config):
         # when an INI contains multiple sections. Unfortunately, it also adds a newline after the
         # _final_ section, resulting in an anomalous trailing newline. To avoid this, write first to
         # memory, then strip the trailing newline.
+        assert depth(cfg) == INIConfig._MAXDEPTH
+
         parser = configparser.ConfigParser()
         s = StringIO()
-        cfgdepth = depth(cfg)
-        assert cfgdepth in (1, 2)  # 2 => .ini
         parser.read_dict(cfg)
-        parser.write(s, space_around_delimiters=opts.space if opts else True)
+        parser.write(s, space_around_delimiters=kwargs.get("space", True))
         with writable(path) as f:
             print(s.getvalue().strip(), file=f)
         s.close()

--- a/src/uwtools/config/formats/ini.py
+++ b/src/uwtools/config/formats/ini.py
@@ -1,9 +1,8 @@
-# pylint: disable=duplicate-code
+# pylint: disable=duplicate-code, unnecessary-comprehension
 import configparser
 from io import StringIO
 
 from uwtools.config.formats.base import Config
-from uwtools.config.support import config_sections
 from uwtools.utils.file import OptionalPath, readable, writable
 
 
@@ -37,11 +36,9 @@ class INIConfig(Config):
         :param config_file: Path to config file to load.
         """
         cfg = configparser.ConfigParser()
-        sections = config_sections(cfg)
         with readable(config_file) as f:
-            raw = f.read()
-            cfg.read_string(raw)
-        return sections
+            cfg.read_string(f.read())
+        return {s: {k: v for k, v in cfg[s].items()} for s in cfg.sections()}
 
     # Public methods
 
@@ -69,7 +66,7 @@ class INIConfig(Config):
         parser = configparser.ConfigParser()
         s = StringIO()
         parser.read_dict(cfg)
-        parser.write(s, space_around_delimiters=True)
+        parser.write(s)
         with writable(path) as f:
             print(s.getvalue().strip(), file=f)
         s.close()

--- a/src/uwtools/config/formats/ini.py
+++ b/src/uwtools/config/formats/ini.py
@@ -12,7 +12,7 @@ class INIConfig(Config):
     Concrete class to handle INI config files.
     """
 
-    _DEPTH = 2
+    DEPTH = 2
 
     def __init__(
         self,
@@ -65,7 +65,6 @@ class INIConfig(Config):
         # when an INI contains multiple sections. Unfortunately, it also adds a newline after the
         # _final_ section, resulting in an anomalous trailing newline. To avoid this, write first to
         # memory, then strip the trailing newline.
-        assert depth(cfg) == INIConfig._DEPTH
 
         parser = configparser.ConfigParser()
         s = StringIO()

--- a/src/uwtools/config/formats/ini.py
+++ b/src/uwtools/config/formats/ini.py
@@ -1,8 +1,6 @@
 # pylint: disable=duplicate-code
 import configparser
 from io import StringIO
-from types import SimpleNamespace as ns
-from typing import Optional
 
 from uwtools.config.formats.base import Config
 from uwtools.config.support import config_sections, depth
@@ -14,7 +12,7 @@ class INIConfig(Config):
     Concrete class to handle INI config files.
     """
 
-    _MAXDEPTH = 2
+    _DEPTH = 2
 
     def __init__(
         self,
@@ -22,8 +20,6 @@ class INIConfig(Config):
     ):
         """
         Construct an INIConfig object.
-
-        Spaces may be included for INI format, but should be excluded for bash.
 
         :param config_file: Path to the config file to load.
         """
@@ -45,7 +41,7 @@ class INIConfig(Config):
         with readable(config_file) as f:
             raw = f.read()
             cfg.read_string(raw)
-            return sections
+        return sections
 
     # Public methods
 
@@ -55,27 +51,26 @@ class INIConfig(Config):
 
         :param path: Path to dump config to.
         """
-        INIConfig.dump_dict(path, self.data, space=True)
+        self.dump_dict(path, self.data)
 
     @staticmethod
-    def dump_dict(path: OptionalPath, cfg: dict, opts: Optional[ns] = None, **kwargs) -> None:
+    def dump_dict(path: OptionalPath, cfg: dict) -> None:
         """
         Dumps a provided config dictionary in INI format.
 
         :param path: Path to dump config to.
         :param cfg: The in-memory config object to dump.
-        :param space_around_delimiters: Place spaces around delimiters?
         """
         # Configparser adds a newline after each section, presumably to create nice-looking output
         # when an INI contains multiple sections. Unfortunately, it also adds a newline after the
         # _final_ section, resulting in an anomalous trailing newline. To avoid this, write first to
         # memory, then strip the trailing newline.
-        assert depth(cfg) == INIConfig._MAXDEPTH
+        assert depth(cfg) == INIConfig._DEPTH
 
         parser = configparser.ConfigParser()
         s = StringIO()
         parser.read_dict(cfg)
-        parser.write(s, space_around_delimiters=kwargs.get("space", True))
+        parser.write(s, space_around_delimiters=True)
         with writable(path) as f:
             print(s.getvalue().strip(), file=f)
         s.close()

--- a/src/uwtools/config/formats/nml.py
+++ b/src/uwtools/config/formats/nml.py
@@ -13,6 +13,8 @@ class NMLConfig(Config):
     Concrete class to handle Fortran namelist files.
     """
 
+    _MAXDEPTH = 2
+
     def __init__(self, config_file) -> None:
         super().__init__(config_file)
         self.parse_include()

--- a/src/uwtools/config/formats/nml.py
+++ b/src/uwtools/config/formats/nml.py
@@ -11,7 +11,7 @@ class NMLConfig(Config):
     Concrete class to handle Fortran namelist files.
     """
 
-    _DEPTH = 2
+    DEPTH = 2
 
     def __init__(self, config_file) -> None:
         super().__init__(config_file)

--- a/src/uwtools/config/formats/nml.py
+++ b/src/uwtools/config/formats/nml.py
@@ -1,6 +1,4 @@
 from collections import OrderedDict
-from types import SimpleNamespace as ns
-from typing import Optional
 
 import f90nml
 
@@ -13,7 +11,7 @@ class NMLConfig(Config):
     Concrete class to handle Fortran namelist files.
     """
 
-    _MAXDEPTH = 2
+    _DEPTH = 2
 
     def __init__(self, config_file) -> None:
         super().__init__(config_file)
@@ -49,16 +47,15 @@ class NMLConfig(Config):
 
         :param path: Path to dump config to.
         """
-        NMLConfig.dump_dict(path, self.data)
+        self.dump_dict(path, self.data)
 
     @staticmethod
-    def dump_dict(path: OptionalPath, cfg: dict, opts: Optional[ns] = None) -> None:
+    def dump_dict(path: OptionalPath, cfg: dict) -> None:
         """
         Dumps a provided config dictionary in Fortran namelist format.
 
         :param path: Path to dump config to.
         :param cfg: The in-memory config object to dump.
-        :param opts: Other options required by a subclass.
         """
 
         # f90nml honors namelist and variable order if it receives an OrderedDict as input, so

--- a/src/uwtools/config/formats/sh.py
+++ b/src/uwtools/config/formats/sh.py
@@ -8,33 +8,30 @@ from uwtools.config.support import depth
 from uwtools.utils.file import OptionalPath, readable, writable
 
 
-class INIConfig(Config):
+class SHConfig(Config):
     """
-    Concrete class to handle INI config files.
+    Concrete class to handle bash config files.
     """
 
     def __init__(
         self,
         config_file: str,
-        space_around_delimiters: bool = True,
     ):
         """
-        Construct an INIConfig object.
+        Construct a SHConfig object.
 
-        Spaces may be included for INI format, but should be excluded for bash.
+        Spaces should be excluded for bash.
 
         :param config_file: Path to the config file to load.
-        :param space_around_delimiters: Include spaces around delimiters?
         """
         super().__init__(config_file)
-        self.space_around_delimiters = space_around_delimiters
         self.parse_include()
 
     # Private methods
 
     def _load(self, config_file: OptionalPath) -> dict:
         """
-        Reads and parses an INI file.
+        Reads and parses a bash file.
 
         See docs for Config._load().
 
@@ -59,31 +56,25 @@ class INIConfig(Config):
 
     def dump(self, path: OptionalPath) -> None:
         """
-        Dumps the config in INI format.
+        Dumps the config in bash format.
 
         :param path: Path to dump config to.
         """
-        INIConfig.dump_dict(path, self.data, ns(space=self.space_around_delimiters))
+        SHConfig.dump_dict(path, self.data, ns(space=False))
 
     @staticmethod
     def dump_dict(path: OptionalPath, cfg: dict, opts: Optional[ns] = None) -> None:
         """
-        Dumps a provided config dictionary in INI format.
+        Dumps a provided config dictionary in bash format.
 
         :param path: Path to dump config to.
         :param cfg: The in-memory config object to dump.
-        :param space_around_delimiters: Place spaces around delimiters?
         """
-        # Configparser adds a newline after each section, presumably to create nice-looking output
-        # when an INI contains multiple sections. Unfortunately, it also adds a newline after the
-        # _final_ section, resulting in an anomalous trailing newline. To avoid this, write first to
-        # memory, then strip the trailing newline.
-        parser = configparser.ConfigParser()
         s = StringIO()
         cfgdepth = depth(cfg)
-        assert cfgdepth == 2  # 2 => .ini
-        parser.read_dict(cfg)
-        parser.write(s, space_around_delimiters=opts.space if opts else True)
+        assert cfgdepth == 1  # 1 => .sh
+        for key, value in cfg.items():
+            print(f"{key}={value}", file=s)
         with writable(path) as f:
             print(s.getvalue().strip(), file=f)
         s.close()

--- a/src/uwtools/config/formats/sh.py
+++ b/src/uwtools/config/formats/sh.py
@@ -12,7 +12,7 @@ class SHConfig(Config):
     Concrete class to handle bash config files.
     """
 
-    _DEPTH = 1
+    DEPTH = 1
 
     def __init__(
         self,
@@ -61,7 +61,6 @@ class SHConfig(Config):
         :param path: Path to dump config to.
         :param cfg: The in-memory config object to dump.
         """
-        assert depth(cfg) == SHConfig._DEPTH
 
         s = StringIO()
         for key, value in cfg.items():

--- a/src/uwtools/config/formats/sh.py
+++ b/src/uwtools/config/formats/sh.py
@@ -3,7 +3,7 @@ import configparser
 from io import StringIO
 
 from uwtools.config.formats.base import Config
-from uwtools.config.support import config_sections, depth
+from uwtools.config.support import config_sections
 from uwtools.utils.file import OptionalPath, readable, writable
 
 

--- a/src/uwtools/config/formats/sh.py
+++ b/src/uwtools/config/formats/sh.py
@@ -1,9 +1,8 @@
-# pylint: disable=duplicate-code
+# pylint: disable=duplicate-code, unnecessary-comprehension
 import configparser
 from io import StringIO
 
 from uwtools.config.formats.base import Config
-from uwtools.config.support import config_sections
 from uwtools.utils.file import OptionalPath, readable, writable
 
 
@@ -37,11 +36,10 @@ class SHConfig(Config):
         :param config_file: Path to config file to load.
         """
         cfg = configparser.ConfigParser()
-        sections = config_sections(cfg)
+        section = "top"
         with readable(config_file) as f:
-            raw = f.read()
-            cfg.read_string("[top]\n" + raw)
-            return dict(sections.get("top"))
+            cfg.read_string(f"[{section}]\n" + f.read())
+        return {k: v for k, v in cfg[section].items()}
 
     # Public methods
 

--- a/src/uwtools/config/formats/sh.py
+++ b/src/uwtools/config/formats/sh.py
@@ -1,8 +1,6 @@
 # pylint: disable=duplicate-code
 import configparser
 from io import StringIO
-from types import SimpleNamespace as ns
-from typing import Optional
 
 from uwtools.config.formats.base import Config
 from uwtools.config.support import config_sections, depth
@@ -14,7 +12,7 @@ class SHConfig(Config):
     Concrete class to handle bash config files.
     """
 
-    _MAXDEPTH = 1
+    _DEPTH = 1
 
     def __init__(
         self,
@@ -32,7 +30,7 @@ class SHConfig(Config):
 
     def _load(self, config_file: OptionalPath) -> dict:
         """
-        Reads and parses a bash file.
+        Reads and parses shell code consisting solely of key=value lines.
 
         See docs for Config._load().
 
@@ -49,21 +47,21 @@ class SHConfig(Config):
 
     def dump(self, path: OptionalPath) -> None:
         """
-        Dumps the config in bash format.
+        Dumps the config as key=value lines.
 
         :param path: Path to dump config to.
         """
-        SHConfig.dump_dict(path, self.data, ns(space=False))
+        self.dump_dict(path, self.data)
 
     @staticmethod
-    def dump_dict(path: OptionalPath, cfg: dict, opts: Optional[ns] = None) -> None:
+    def dump_dict(path: OptionalPath, cfg: dict) -> None:
         """
         Dumps a provided config dictionary in bash format.
 
         :param path: Path to dump config to.
         :param cfg: The in-memory config object to dump.
         """
-        assert depth(cfg) == SHConfig._MAXDEPTH
+        assert depth(cfg) == SHConfig._DEPTH
 
         s = StringIO()
         for key, value in cfg.items():

--- a/src/uwtools/config/formats/sh.py
+++ b/src/uwtools/config/formats/sh.py
@@ -1,4 +1,4 @@
-# pylint: disable=duplicate-code, unnecessary-comprehension
+# pylint: disable=duplicate-code
 import configparser
 from io import StringIO
 
@@ -39,7 +39,7 @@ class SHConfig(Config):
         section = "top"
         with readable(config_file) as f:
             cfg.read_string(f"[{section}]\n" + f.read())
-        return {k: v for k, v in cfg[section].items()}
+        return dict(cfg[section].items())
 
     # Public methods
 

--- a/src/uwtools/config/formats/yaml.py
+++ b/src/uwtools/config/formats/yaml.py
@@ -39,6 +39,8 @@ class YAMLConfig(Config):
     Concrete class to handle YAML config files.
     """
 
+    _MAXDEPTH = 8
+
     def __repr__(self) -> str:
         """
         The string representation of a YAMLConfig object.

--- a/src/uwtools/config/formats/yaml.py
+++ b/src/uwtools/config/formats/yaml.py
@@ -38,7 +38,7 @@ class YAMLConfig(Config):
     Concrete class to handle YAML config files.
     """
 
-    _DEPTH = None
+    DEPTH = None
 
     def __repr__(self) -> str:
         """

--- a/src/uwtools/config/formats/yaml.py
+++ b/src/uwtools/config/formats/yaml.py
@@ -1,5 +1,4 @@
 from types import SimpleNamespace as ns
-from typing import Optional
 
 import yaml
 
@@ -39,7 +38,7 @@ class YAMLConfig(Config):
     Concrete class to handle YAML config files.
     """
 
-    _MAXDEPTH = 8
+    _DEPTH = None
 
     def __repr__(self) -> str:
         """
@@ -101,10 +100,10 @@ class YAMLConfig(Config):
 
         :param path: Path to dump config to.
         """
-        YAMLConfig.dump_dict(path, self.data)
+        self.dump_dict(path, self.data)
 
     @staticmethod
-    def dump_dict(path: OptionalPath, cfg: dict, opts: Optional[ns] = None) -> None:
+    def dump_dict(path: OptionalPath, cfg: dict) -> None:
         """
         Dumps a provided config dictionary in YAML format.
 

--- a/src/uwtools/config/support.py
+++ b/src/uwtools/config/support.py
@@ -29,6 +29,7 @@ def format_to_config(fmt: str) -> Type:
         FORMAT.fieldtable: "FieldTableConfig",
         FORMAT.ini: "INIConfig",
         FORMAT.nml: "NMLConfig",
+        FORMAT.sh: "SHConfig",
         FORMAT.yaml: "YAMLConfig",
     }
     if not fmt in lookup:

--- a/src/uwtools/config/support.py
+++ b/src/uwtools/config/support.py
@@ -1,19 +1,12 @@
 import configparser
 from importlib import import_module
-from typing import Dict, Type
+from typing import Type
 
 from uwtools.exceptions import UWConfigError
 from uwtools.logging import log
 from uwtools.utils.file import FORMAT
 
 INCLUDE_TAG = "!INCLUDE"
-
-
-def to_dict(config: configparser.ConfigParser) -> Dict[str, Dict[str, str]]:
-    """
-    Return a dictionary of sections from a config object.
-    """
-    return {section_name: dict(config[section_name]) for section_name in config.sections()}
 
 
 def config_sections(config: configparser.ConfigParser):

--- a/src/uwtools/config/support.py
+++ b/src/uwtools/config/support.py
@@ -1,11 +1,29 @@
+import configparser
 from importlib import import_module
-from typing import Type
+from typing import Dict, Type
 
 from uwtools.exceptions import UWConfigError
 from uwtools.logging import log
 from uwtools.utils.file import FORMAT
 
 INCLUDE_TAG = "!INCLUDE"
+
+
+def to_dict(config: configparser.ConfigParser) -> Dict[str, Dict[str, str]]:
+    """
+    Return a dictionary of sections from a config object.
+    """
+    return {section_name: dict(config[section_name]) for section_name in config.sections()}
+
+
+def config_sections(config: configparser.ConfigParser):
+    """
+    Access the _sections method of a config object.
+    """
+    # The protected _sections method is the most straightforward way to get at the dict
+    # representation of the parse config.
+    config.optionxform = str  # type: ignore
+    return config._sections  # type: ignore # pylint: disable=protected-access
 
 
 def depth(d: dict) -> int:

--- a/src/uwtools/config/support.py
+++ b/src/uwtools/config/support.py
@@ -1,4 +1,3 @@
-import configparser
 from importlib import import_module
 from typing import Type
 
@@ -7,19 +6,6 @@ from uwtools.logging import log
 from uwtools.utils.file import FORMAT
 
 INCLUDE_TAG = "!INCLUDE"
-
-
-def config_sections(config: configparser.ConfigParser):
-    """
-    Access the _sections method of a config object.
-
-    :param config: The ConfigParser object
-    :return: the _sections method of the ConfigParser object
-    """
-    # The protected _sections method is the most straightforward way to get at the dict
-    # representation of the parse config.
-    config.optionxform = str  # type: ignore
-    return config._sections  # type: ignore # pylint: disable=protected-access
 
 
 def depth(d: dict) -> int:

--- a/src/uwtools/config/support.py
+++ b/src/uwtools/config/support.py
@@ -12,6 +12,9 @@ INCLUDE_TAG = "!INCLUDE"
 def config_sections(config: configparser.ConfigParser):
     """
     Access the _sections method of a config object.
+
+    :param config: The ConfigParser object
+    :return: the _sections method of the ConfigParser object
     """
     # The protected _sections method is the most straightforward way to get at the dict
     # representation of the parse config.

--- a/src/uwtools/config/tools.py
+++ b/src/uwtools/config/tools.py
@@ -112,10 +112,8 @@ def _realize_config_check_depths(input_obj: Config, output_format: str) -> None:
     :param output_format: The output format:
     :raises: UWConfigError on excessive input-config depth.
     """
-    if (
-        (output_format == FORMAT.ini and input_obj.depth > 2)
-        or (output_format == FORMAT.nml and input_obj.depth != 2)
-        or (output_format == FORMAT.sh and input_obj.depth != 1)
+    if (output_format == (FORMAT.ini or FORMAT.nml) and input_obj.depth != 2) or (
+        output_format == FORMAT.sh and input_obj.depth != 1
     ):
         msg = "Cannot write depth-%s input to type-'%s' output" % (input_obj.depth, output_format)
         log.error(msg)

--- a/src/uwtools/config/tools.py
+++ b/src/uwtools/config/tools.py
@@ -9,7 +9,7 @@ from uwtools.config.support import format_to_config, log_and_error
 from uwtools.exceptions import UWConfigError
 from uwtools.logging import MSGWIDTH, log
 from uwtools.types import DefinitePath, OptionalPath
-from uwtools.utils.file import FORMAT, get_file_type
+from uwtools.utils.file import get_file_type
 
 # Public functions
 
@@ -112,9 +112,8 @@ def _realize_config_check_depths(input_obj: Config, output_format: str) -> None:
     :param output_format: The output format:
     :raises: UWConfigError on excessive input-config depth.
     """
-    if (output_format == (FORMAT.ini or FORMAT.nml) and input_obj.depth != 2) or (
-        output_format == FORMAT.sh and input_obj.depth != 1
-    ):
+    cfgclass = format_to_config(output_format)
+    if cfgclass.DEPTH and input_obj.depth != cfgclass.DEPTH:
         msg = "Cannot write depth-%s input to type-'%s' output" % (input_obj.depth, output_format)
         log.error(msg)
         raise UWConfigError(msg)

--- a/src/uwtools/config/tools.py
+++ b/src/uwtools/config/tools.py
@@ -112,8 +112,10 @@ def _realize_config_check_depths(input_obj: Config, output_format: str) -> None:
     :param output_format: The output format:
     :raises: UWConfigError on excessive input-config depth.
     """
-    if (output_format == FORMAT.ini and input_obj.depth > 2) or (
-        output_format == FORMAT.nml and input_obj.depth != 2
+    if (
+        (output_format == FORMAT.ini and input_obj.depth > 2)
+        or (output_format == FORMAT.nml and input_obj.depth != 2)
+        or (output_format == FORMAT.sh and input_obj.depth != 1)
     ):
         msg = "Cannot write depth-%s input to type-'%s' output" % (input_obj.depth, output_format)
         log.error(msg)

--- a/src/uwtools/tests/config/formats/test_base.py
+++ b/src/uwtools/tests/config/formats/test_base.py
@@ -75,15 +75,15 @@ def test_characterize_values(config):
     assert template == ["    p3: {{ n }}"]
 
 
-@pytest.mark.parametrize("fmt", [FORMAT.ini, FORMAT.nml, FORMAT.sh, FORMAT.yaml])
+@pytest.mark.parametrize("fmt", [FORMAT.ini, FORMAT.nml, FORMAT.yaml])
 def test_compare_config(caplog, fmt, salad_base):
     """
     Compare two config objects.
     """
     log.setLevel(logging.INFO)
     cfgobj = tools.format_to_config(fmt)(fixture_path(f"simple.{fmt}"))
-    if fmt == FORMAT.ini or FORMAT.sh:
-        salad_base["salad"]["how_many"] = "12"  # str "12" (not int 12) for ini or sh
+    if fmt == FORMAT.ini:
+        salad_base["salad"]["how_many"] = "12"  # str "12" (not int 12) for ini
     assert cfgobj.compare_config(salad_base) is True
     # Expect no differences:
     assert not caplog.records
@@ -159,8 +159,8 @@ def test_update_values(config):
     assert config == {"foo": 88, "a": "11", "b": "12", "c": "13"}
 
 
-@pytest.mark.parametrize("fmt1", [FORMAT.ini, FORMAT.nml, FORMAT.sh, FORMAT.yaml])
-@pytest.mark.parametrize("fmt2", [FORMAT.ini, FORMAT.nml, FORMAT.sh, FORMAT.yaml])
+@pytest.mark.parametrize("fmt1", [FORMAT.ini, FORMAT.nml, FORMAT.yaml])
+@pytest.mark.parametrize("fmt2", [FORMAT.ini, FORMAT.nml, FORMAT.yaml])
 def test_transform_config(fmt1, fmt2, tmp_path):
     """
     Test that transforms config objects to objects of other config subclasses.

--- a/src/uwtools/tests/config/formats/test_base.py
+++ b/src/uwtools/tests/config/formats/test_base.py
@@ -75,14 +75,14 @@ def test_characterize_values(config):
     assert template == ["    p3: {{ n }}"]
 
 
-@pytest.mark.parametrize("fmt", [FORMAT.ini, FORMAT.nml, FORMAT.yaml])
+@pytest.mark.parametrize("fmt", [FORMAT.ini, FORMAT.nml, FORMAT.sh, FORMAT.yaml])
 def test_compare_config(caplog, fmt, salad_base):
     """
     Compare two config objects.
     """
     log.setLevel(logging.INFO)
     cfgobj = tools.format_to_config(fmt)(fixture_path(f"simple.{fmt}"))
-    if fmt == FORMAT.ini:
+    if fmt == FORMAT.ini or FORMAT.sh:
         salad_base["salad"]["how_many"] = "12"  # str "12" (not int 12) for ini
     assert cfgobj.compare_config(salad_base) is True
     # Expect no differences:
@@ -159,8 +159,8 @@ def test_update_values(config):
     assert config == {"foo": 88, "a": "11", "b": "12", "c": "13"}
 
 
-@pytest.mark.parametrize("fmt1", [FORMAT.ini, FORMAT.nml, FORMAT.yaml])
-@pytest.mark.parametrize("fmt2", [FORMAT.ini, FORMAT.nml, FORMAT.yaml])
+@pytest.mark.parametrize("fmt1", [FORMAT.ini, FORMAT.nml, FORMAT.sh, FORMAT.yaml])
+@pytest.mark.parametrize("fmt2", [FORMAT.ini, FORMAT.nml, FORMAT.sh, FORMAT.yaml])
 def test_transform_config(fmt1, fmt2, tmp_path):
     """
     Test that transforms config objects to objects of other config subclasses.

--- a/src/uwtools/tests/config/formats/test_base.py
+++ b/src/uwtools/tests/config/formats/test_base.py
@@ -83,7 +83,7 @@ def test_compare_config(caplog, fmt, salad_base):
     log.setLevel(logging.INFO)
     cfgobj = tools.format_to_config(fmt)(fixture_path(f"simple.{fmt}"))
     if fmt == FORMAT.ini or FORMAT.sh:
-        salad_base["salad"]["how_many"] = "12"  # str "12" (not int 12) for ini
+        salad_base["salad"]["how_many"] = "12"  # str "12" (not int 12) for ini or sh
     assert cfgobj.compare_config(salad_base) is True
     # Expect no differences:
     assert not caplog.records

--- a/src/uwtools/tests/config/formats/test_ini.py
+++ b/src/uwtools/tests/config/formats/test_ini.py
@@ -13,7 +13,7 @@ from uwtools.tests.support import fixture_path
 
 def test_parse_include():
     """
-    Test that an INI file with no sections handles include tags properly.
+    Test that an INI file handles include tags properly.
     """
     cfgobj = INIConfig(fixture_path("include_files.ini"))
     assert cfgobj["config"]["fruit"] == "papaya"

--- a/src/uwtools/tests/config/formats/test_ini.py
+++ b/src/uwtools/tests/config/formats/test_ini.py
@@ -13,7 +13,7 @@ from uwtools.tests.support import fixture_path
 
 def test_parse_include():
     """
-    Test that non-YAML handles include tags properly for INI with no sections.
+    Test that an INI file with no sections handles include tags properly.
     """
     cfgobj = INIConfig(fixture_path("include_files.ini"))
     assert cfgobj["config"]["fruit"] == "papaya"

--- a/src/uwtools/tests/config/formats/test_ini.py
+++ b/src/uwtools/tests/config/formats/test_ini.py
@@ -15,11 +15,11 @@ def test_parse_include():
     """
     Test that non-YAML handles include tags properly for INI with no sections.
     """
-    cfgobj = INIConfig(fixture_path("include_files.ini"), space_around_delimiters=True)
-    assert cfgobj.get("fruit") == "papaya"
-    assert cfgobj.get("how_many") == "17"
-    assert cfgobj.get("meat") == "beef"
-    assert len(cfgobj) == 5
+    cfgobj = INIConfig(fixture_path("include_files.ini"))
+    assert cfgobj["config"]["fruit"] == "papaya"
+    assert cfgobj["config"]["how_many"] == "17"
+    assert cfgobj["config"]["meat"] == "beef"
+    assert len(cfgobj["config"]) == 5
 
 
 def test_simple(salad_base, tmp_path):

--- a/src/uwtools/tests/config/formats/test_sh.py
+++ b/src/uwtools/tests/config/formats/test_sh.py
@@ -1,6 +1,6 @@
 # pylint: disable=duplicate-code
 """
-Tests for uwtools.config.formats.ini module.
+Tests for uwtools.config.formats.sh module.
 """
 
 import filecmp
@@ -17,9 +17,9 @@ def test_parse_include():
     Test that non-YAML handles include tags properly for bash with no sections.
     """
     cfgobj = SHConfig(fixture_path("include_files.sh"))
-    assert cfgobj.get("fruit") == "papaya"
-    assert cfgobj.get("how_many") == "17"
-    assert cfgobj.get("meat") == "beef"
+    assert cfgobj["fruit"] == "papaya"
+    assert cfgobj["how_many"] == "17"
+    assert cfgobj["meat"] == "beef"
     assert len(cfgobj) == 5
 
 

--- a/src/uwtools/tests/config/formats/test_sh.py
+++ b/src/uwtools/tests/config/formats/test_sh.py
@@ -23,9 +23,9 @@ def test_parse_include():
     assert len(cfgobj) == 5
 
 
-def test_bash(salad_base, tmp_path):
+def test_sh(salad_base, tmp_path):
     """
-    Test that bash config load and dump work with a basic bash file.
+    Test that sh config load and dump work with a basic sh file.
     """
     infile = fixture_path("simple.sh")
     outfile = tmp_path / "outfile.sh"

--- a/src/uwtools/tests/config/formats/test_sh.py
+++ b/src/uwtools/tests/config/formats/test_sh.py
@@ -4,8 +4,9 @@ Tests for uwtools.config.formats.ini module.
 """
 
 import filecmp
+from typing import Any, Dict
 
-from uwtools.config.formats.ini import INIConfig
+from uwtools.config.formats.sh import SHConfig
 from uwtools.tests.support import fixture_path
 
 # Tests
@@ -13,26 +14,26 @@ from uwtools.tests.support import fixture_path
 
 def test_parse_include():
     """
-    Test that non-YAML handles include tags properly for INI with no sections.
+    Test that non-YAML handles include tags properly for bash with no sections.
     """
-    cfgobj = INIConfig(fixture_path("include_files.ini"), space_around_delimiters=True)
+    cfgobj = SHConfig(fixture_path("include_files.sh"))
     assert cfgobj.get("fruit") == "papaya"
     assert cfgobj.get("how_many") == "17"
     assert cfgobj.get("meat") == "beef"
     assert len(cfgobj) == 5
 
 
-def test_simple(salad_base, tmp_path):
+def test_bash(salad_base, tmp_path):
     """
-    Test that INI config load and dump work with a basic INI file.
-
-    Everything in INI is treated as a string!
+    Test that bash config load and dump work with a basic bash file.
     """
-    infile = fixture_path("simple.ini")
-    outfile = tmp_path / "outfile.ini"
-    cfgobj = INIConfig(infile)
-    expected = salad_base
-    expected["salad"]["how_many"] = "12"  # str "12" (not int 12) for INI
+    infile = fixture_path("simple.sh")
+    outfile = tmp_path / "outfile.sh"
+    cfgobj = SHConfig(infile)
+    expected: Dict[str, Any] = {
+        **salad_base["salad"],
+        "how_many": "12",
+    }
     assert cfgobj == expected
     cfgobj.dump(outfile)
     assert filecmp.cmp(infile, outfile)

--- a/src/uwtools/tests/config/formats/test_sh.py
+++ b/src/uwtools/tests/config/formats/test_sh.py
@@ -14,7 +14,7 @@ from uwtools.tests.support import fixture_path
 
 def test_parse_include():
     """
-    Test that non-YAML handles include tags properly for bash with no sections.
+    Test that an sh file with no sections handles include tags properly.
     """
     cfgobj = SHConfig(fixture_path("include_files.sh"))
     assert cfgobj["fruit"] == "papaya"

--- a/src/uwtools/tests/config/test_support.py
+++ b/src/uwtools/tests/config/test_support.py
@@ -3,7 +3,6 @@
 Tests for uwtools.config.jinja2 module.
 """
 
-import configparser
 import logging
 
 import pytest
@@ -19,13 +18,6 @@ from uwtools.exceptions import UWConfigError
 from uwtools.logging import log
 from uwtools.tests.support import logged
 from uwtools.utils.file import FORMAT
-
-
-def test_config_sections():
-    cfg = configparser.ConfigParser()
-    sections = support.config_sections(cfg)
-    cfg.read_string("[flower]\nroses=red\n[fruit]\na=apple\n")
-    assert dict(sections) == {"flower": {"roses": "red"}, "fruit": {"a": "apple"}}
 
 
 @pytest.mark.parametrize("d,n", [({1: 88}, 1), ({1: {2: 88}}, 2), ({1: {2: {3: 88}}}, 3)])

--- a/src/uwtools/tests/config/test_support.py
+++ b/src/uwtools/tests/config/test_support.py
@@ -3,6 +3,7 @@
 Tests for uwtools.config.jinja2 module.
 """
 
+import configparser
 import logging
 
 import pytest
@@ -12,11 +13,19 @@ from uwtools.config import support
 from uwtools.config.formats.fieldtable import FieldTableConfig
 from uwtools.config.formats.ini import INIConfig
 from uwtools.config.formats.nml import NMLConfig
+from uwtools.config.formats.sh import SHConfig
 from uwtools.config.formats.yaml import YAMLConfig
 from uwtools.exceptions import UWConfigError
 from uwtools.logging import log
 from uwtools.tests.support import logged
 from uwtools.utils.file import FORMAT
+
+
+def test_config_sections():
+    cfg = configparser.ConfigParser()
+    sections = support.config_sections(cfg)
+    cfg.read_string("[top]\n")
+    assert not dict(sections.get("top"))
 
 
 @pytest.mark.parametrize("d,n", [({1: 88}, 1), ({1: {2: 88}}, 2), ({1: {2: {3: 88}}}, 3)])
@@ -30,6 +39,7 @@ def test_depth(d, n):
         (FieldTableConfig, FORMAT.fieldtable),
         (INIConfig, FORMAT.ini),
         (NMLConfig, FORMAT.nml),
+        (SHConfig, FORMAT.sh),
         (YAMLConfig, FORMAT.yaml),
     ],
 )

--- a/src/uwtools/tests/config/test_support.py
+++ b/src/uwtools/tests/config/test_support.py
@@ -24,8 +24,8 @@ from uwtools.utils.file import FORMAT
 def test_config_sections():
     cfg = configparser.ConfigParser()
     sections = support.config_sections(cfg)
-    cfg.read_string("[top]\n")
-    assert not dict(sections.get("top"))
+    cfg.read_string("[flower]\nroses=red\n[fruit]\na=apple\n")
+    assert dict(sections) == {"flower": {"roses": "red"}, "fruit": {"a": "apple"}}
 
 
 @pytest.mark.parametrize("d,n", [({1: 88}, 1), ({1: {2: 88}}, 2), ({1: {2: {3: 88}}}, 3)])

--- a/src/uwtools/tests/config/test_tools.py
+++ b/src/uwtools/tests/config/test_tools.py
@@ -13,6 +13,7 @@ from pytest import fixture, raises
 from uwtools.config import tools
 from uwtools.config.formats.ini import INIConfig
 from uwtools.config.formats.nml import NMLConfig
+from uwtools.config.formats.sh import SHConfig
 from uwtools.config.formats.yaml import YAMLConfig
 from uwtools.exceptions import UWConfigError
 from uwtools.logging import log
@@ -136,7 +137,7 @@ def test_compare_configs_bad_format(caplog):
             config_b_path="/not/used",
             config_b_format=FORMAT.yaml,
         )
-    msg = "Format 'jpg' should be one of: fieldtable, ini, nml, yaml"
+    msg = "Format 'jpg' should be one of: fieldtable, ini, nml, sh, yaml"
     assert logged(caplog, msg)
     assert msg in str(e.value)
 
@@ -324,9 +325,9 @@ def test_realize_config_output_file_conversion(tmp_path):
 
 def test_realize_config_simple_bash(tmp_path):
     """
-    Test that providing a bash file with necessary settings will create an INI config file.
+    Test that providing a bash file with necessary settings will create an sh config file.
     """
-    help_realize_config_simple("simple.sh", FORMAT.ini, tmp_path)
+    help_realize_config_simple("simple.sh", FORMAT.sh, tmp_path)
 
 
 def test_realize_config_simple_namelist(tmp_path):

--- a/src/uwtools/tests/config/test_tools.py
+++ b/src/uwtools/tests/config/test_tools.py
@@ -426,7 +426,7 @@ Keys that are set to empty:
     assert actual == expected
 
 
-def test_reallize_config_values_needed_yaml(caplog):
+def test_realize_config_values_needed_yaml(caplog):
     """
     Test that the values_needed flag logs keys completed, keys containing unfilled Jinja2 templates,
     and keys set to empty.

--- a/src/uwtools/tests/config/test_tools.py
+++ b/src/uwtools/tests/config/test_tools.py
@@ -176,13 +176,13 @@ def test_realize_config_depth_mismatch_to_ini(realize_config_yaml_input):
         )
 
 
-def test_realize_config_depth_mismatch_to_nml(realize_config_yaml_input):
+def test_realize_config_depth_mismatch_to_sh(realize_config_yaml_input):
     with raises(UWConfigError):
         tools.realize_config(
             input_file=realize_config_yaml_input,
             input_format=FORMAT.yaml,
             output_file=None,
-            output_format=FORMAT.nml,
+            output_format=FORMAT.sh,
             values_file=None,
             values_format=None,
         )
@@ -523,8 +523,8 @@ def test__print_config_section_yaml_not_dict():
     assert "must be a dictionary" in str(e.value)
 
 
-@pytest.mark.parametrize("fmt", ["ini", "nml"])
-def test__realize_config_check_depths_fail_nml(fmt, realize_config_testobj):
+@pytest.mark.parametrize("fmt", ["ini", "sh"])
+def test__realize_config_check_depths_fail_sh(fmt, realize_config_testobj):
     with raises(UWConfigError):
         tools._realize_config_check_depths(input_obj=realize_config_testobj, output_format=fmt)
 

--- a/src/uwtools/tests/config/test_tools.py
+++ b/src/uwtools/tests/config/test_tools.py
@@ -13,7 +13,6 @@ from pytest import fixture, raises
 from uwtools.config import tools
 from uwtools.config.formats.ini import INIConfig
 from uwtools.config.formats.nml import NMLConfig
-from uwtools.config.formats.sh import SHConfig
 from uwtools.config.formats.yaml import YAMLConfig
 from uwtools.exceptions import UWConfigError
 from uwtools.logging import log

--- a/src/uwtools/tests/config/test_tools.py
+++ b/src/uwtools/tests/config/test_tools.py
@@ -322,11 +322,12 @@ def test_realize_config_output_file_conversion(tmp_path):
         assert f.read()[-1] == "\n"
 
 
-def test_realize_config_simple_bash(tmp_path):
+def test_realize_config_simple_ini(tmp_path):
     """
-    Test that providing a bash file with necessary settings will create an sh config file.
+    Test that providing an INI file with necessary settings will create an INI config file.
     """
-    help_realize_config_simple("simple.sh", FORMAT.sh, tmp_path)
+
+    help_realize_config_simple("simple.ini", FORMAT.ini, tmp_path)
 
 
 def test_realize_config_simple_namelist(tmp_path):
@@ -336,12 +337,11 @@ def test_realize_config_simple_namelist(tmp_path):
     help_realize_config_simple("simple.nml", FORMAT.nml, tmp_path)
 
 
-def test_realize_config_simple_ini(tmp_path):
+def test_realize_config_simple_sh(tmp_path):
     """
-    Test that providing an INI file with necessary settings will create an INI config file.
+    Test that providing an sh file with necessary settings will create an sh config file.
     """
-
-    help_realize_config_simple("simple.ini", FORMAT.ini, tmp_path)
+    help_realize_config_simple("simple.sh", FORMAT.sh, tmp_path)
 
 
 def test_realize_config_simple_yaml(tmp_path):

--- a/src/uwtools/tests/fixtures/fruit_config.ini
+++ b/src/uwtools/tests/fixtures/fruit_config.ini
@@ -1,0 +1,4 @@
+fruit = papaya
+vegetable = eggplant
+how_many = 17
+dressing = ranch

--- a/src/uwtools/tests/fixtures/fruit_config.ini
+++ b/src/uwtools/tests/fixtures/fruit_config.ini
@@ -1,3 +1,4 @@
+[config]
 fruit = papaya
 vegetable = eggplant
 how_many = 17

--- a/src/uwtools/tests/fixtures/include_files.ini
+++ b/src/uwtools/tests/fixtures/include_files.ini
@@ -1,0 +1,3 @@
+salad_include = !INCLUDE [./fruit_config.ini]
+meat = beef
+dressing = poppyseed

--- a/src/uwtools/tests/fixtures/include_files.ini
+++ b/src/uwtools/tests/fixtures/include_files.ini
@@ -1,3 +1,4 @@
+[config]
 salad_include = !INCLUDE [./fruit_config.ini]
 meat = beef
 dressing = poppyseed

--- a/src/uwtools/tests/utils/test_file.py
+++ b/src/uwtools/tests/utils/test_file.py
@@ -58,20 +58,20 @@ def test__stdinproxy():
 def test_get_file_type():
     for ext, file_type in {
         "atparse": "atparse",
-        "bash": "ini",
+        "bash": "sh",
         "cfg": "ini",
         "fieldtable": "fieldtable",
         "ini": "ini",
         "jinja2": "jinja2",
         "nml": "nml",
-        "sh": "ini",
+        "sh": "sh",
         "yaml": "yaml",
         "yml": "yaml",
     }.items():
         assert file.get_file_type(f"a.{ext}") == file_type
 
 
-def test_get_file_type_unrecignized():
+def test_get_file_type_unrecognized():
     with raises(ValueError):
         file.get_file_type("a.jpg")
 

--- a/src/uwtools/utils/file.py
+++ b/src/uwtools/utils/file.py
@@ -30,19 +30,20 @@ class FORMAT:
     _ini: str = "ini"
     _jinja2: str = "jinja2"
     _nml: str = "nml"
+    _sh: str = "sh"
     _xml: str = "xml"
     _yaml: str = "yaml"
 
     # Variants:
 
     atparse: str = _atparse
-    bash: str = _ini
+    bash: str = _sh
     cfg: str = _ini
     fieldtable: str = _fieldtable
     ini: str = _ini
     jinja2: str = _jinja2
     nml: str = _nml
-    sh: str = _ini
+    sh: str = _sh
     yaml: str = _yaml
     yml: str = _yaml
 


### PR DESCRIPTION
**Description**

INI and SH differences should be handled uniquely. This separates bash handling out of INIConfig to SHConfig and updates affected classes and tests accordingly

Completes issue #347 

**Type**

Select one or more:

- [x] Bug fix (corrects a known issue)
- [x] Code maintenance (refactoring, etc. without behavior change)
- [x] Documentation
- [ ] Enhancement (adds a new functionality)
- [ ] Tooling (CI, code-quality, packaging, revision-control, etc.)

**Impact**

Select one:

- [x] This is a non-breaking change (existing functionality continues to work as expected)
- [ ] This is a breaking change (changes existing functionality)

**Checklist**

Affirm:

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
