### PR TITLE
Misc updates 2023-12-06

### DIFF
--- a/src/uwtools/config/formats/base.py
+++ b/src/uwtools/config/formats/base.py
@@ -12,6 +12,7 @@ import yaml
 
 from uwtools.config.jinja2 import dereference
 from uwtools.config.support import INCLUDE_TAG, depth, log_and_error
+from uwtools.exceptions import UWConfigError
 from uwtools.logging import log
 from uwtools.types import OptionalPath
 
@@ -35,6 +36,11 @@ class Config(ABC, UserDict):
         else:
             self._config_file = str(config) if config else None
             self.update(self._load(self._config_file))
+        if self.get_depth_threshold() and self.depth != self.get_depth_threshold():
+            raise UWConfigError(
+                "Cannot instantiate depth-%s %s with depth-%s config"
+                % (self.get_depth_threshold(), type(self).__name__, self.depth)
+            )
 
     def __repr__(self) -> str:
         """

--- a/src/uwtools/config/formats/base.py
+++ b/src/uwtools/config/formats/base.py
@@ -177,6 +177,13 @@ class Config(ABC, UserDict):
 
     @staticmethod
     @abstractmethod
+    def get_depth_threshold() -> Optional[int]:
+        """
+        Returns the config's depth threshold.
+        """
+
+    @staticmethod
+    @abstractmethod
     def dump_dict(path: OptionalPath, cfg: dict) -> None:
         """
         Dumps a provided config dictionary to stdout or a file.

--- a/src/uwtools/config/formats/fieldtable.py
+++ b/src/uwtools/config/formats/fieldtable.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from uwtools.config.formats.yaml import YAMLConfig
 from uwtools.utils.file import FORMAT, OptionalPath, writable
 
@@ -8,7 +10,6 @@ class FieldTableConfig(YAMLConfig):
     an input YAML file.
     """
 
-    DEPTH = None
     # Public methods
 
     def dump(self, path: OptionalPath) -> None:
@@ -59,6 +60,13 @@ class FieldTableConfig(YAMLConfig):
             lines[-1] += " /"
         with writable(path) as f:
             print("\n".join(lines), file=f)
+
+    @staticmethod
+    def get_depth_threshold() -> Optional[int]:
+        """
+        Returns the config's depth threshold.
+        """
+        return None
 
     @staticmethod
     def get_format() -> str:

--- a/src/uwtools/config/formats/ini.py
+++ b/src/uwtools/config/formats/ini.py
@@ -2,7 +2,7 @@
 
 import configparser
 from io import StringIO
-from typing import Union
+from typing import Optional, Union
 
 from uwtools.config.formats.base import Config
 from uwtools.config.tools import config_check_depths_dump
@@ -13,8 +13,6 @@ class INIConfig(Config):
     """
     Concrete class to handle INI config files.
     """
-
-    DEPTH = 2
 
     def __init__(self, config: Union[dict, OptionalPath] = None):
         """
@@ -73,6 +71,13 @@ class INIConfig(Config):
         with writable(path) as f:
             print(s.getvalue().strip(), file=f)
         s.close()
+
+    @staticmethod
+    def get_depth_threshold() -> Optional[int]:
+        """
+        Returns the config's depth threshold.
+        """
+        return 2
 
     @staticmethod
     def get_format() -> str:

--- a/src/uwtools/config/formats/nml.py
+++ b/src/uwtools/config/formats/nml.py
@@ -1,5 +1,5 @@
 from collections import OrderedDict
-from typing import Union
+from typing import Optional, Union
 
 import f90nml
 
@@ -12,8 +12,6 @@ class NMLConfig(Config):
     """
     Concrete class to handle Fortran namelist files.
     """
-
-    DEPTH = 2
 
     def __init__(self, config: Union[dict, OptionalPath] = None) -> None:
         """
@@ -79,6 +77,13 @@ class NMLConfig(Config):
 
         with writable(path) as f:
             f90nml.Namelist(to_od(cfg)).write(f, sort=False)
+
+    @staticmethod
+    def get_depth_threshold() -> Optional[int]:
+        """
+        Returns the config's depth threshold.
+        """
+        return 2
 
     @staticmethod
     def get_format() -> str:

--- a/src/uwtools/config/formats/sh.py
+++ b/src/uwtools/config/formats/sh.py
@@ -2,7 +2,7 @@
 
 import configparser
 from io import StringIO
-from typing import Union
+from typing import Optional, Union
 
 from uwtools.config.formats.base import Config
 from uwtools.config.tools import config_check_depths_dump
@@ -13,8 +13,6 @@ class SHConfig(Config):
     """
     Concrete class to handle bash config files.
     """
-
-    DEPTH = 1
 
     def __init__(self, config: Union[dict, OptionalPath] = None):
         """
@@ -70,6 +68,13 @@ class SHConfig(Config):
         with writable(path) as f:
             print(s.getvalue().strip(), file=f)
         s.close()
+
+    @staticmethod
+    def get_depth_threshold() -> Optional[int]:
+        """
+        Returns the config's depth threshold.
+        """
+        return 1
 
     @staticmethod
     def get_format() -> str:

--- a/src/uwtools/config/formats/yaml.py
+++ b/src/uwtools/config/formats/yaml.py
@@ -1,4 +1,5 @@
 from types import SimpleNamespace as ns
+from typing import Optional
 
 import yaml
 
@@ -37,8 +38,6 @@ class YAMLConfig(Config):
     """
     Concrete class to handle YAML config files.
     """
-
-    DEPTH = None
 
     def __repr__(self) -> str:
         """
@@ -113,6 +112,13 @@ class YAMLConfig(Config):
         """
         with writable(path) as f:
             yaml.dump(cfg, f, sort_keys=False)
+
+    @staticmethod
+    def get_depth_threshold() -> Optional[int]:
+        """
+        Returns the config's depth threshold.
+        """
+        return None
 
     @staticmethod
     def get_format() -> str:

--- a/src/uwtools/config/tools.py
+++ b/src/uwtools/config/tools.py
@@ -237,7 +237,7 @@ def _validate_depth(
     """
     target_class = format_to_config(target_format)
     config = config_obj.data if isinstance(config_obj, Config) else config_obj
-    if bad_depth(target_class.DEPTH, depth(config)):
+    if bad_depth(target_class.get_depth_threshold(), depth(config)):
         raise log_and_error(
             "Cannot %s depth-%s config to type-'%s' config" % (action, depth(config), target_format)
         )

--- a/src/uwtools/tests/config/formats/test_base.py
+++ b/src/uwtools/tests/config/formats/test_base.py
@@ -51,6 +51,10 @@ class ConcreteConfig(Config):
         pass
 
     @staticmethod
+    def get_depth_threshold():
+        pass
+
+    @staticmethod
     def get_format():
         pass
 

--- a/src/uwtools/tests/config/formats/test_fieldtable.py
+++ b/src/uwtools/tests/config/formats/test_fieldtable.py
@@ -10,8 +10,17 @@ from uwtools.utils.file import FORMAT
 # Tests
 
 
-def test_format():
+def test_get_format():
     assert FieldTableConfig.get_format() == FORMAT.fieldtable
+
+
+def test_get_depth_threshold():
+    assert FieldTableConfig.get_depth_threshold() is None
+
+
+def test_instantiation_depth():
+    # Any depth is fine.
+    assert FieldTableConfig(config={1: {2: {3: 4}}})
 
 
 def test_simple(tmp_path):

--- a/src/uwtools/tests/config/formats/test_ini.py
+++ b/src/uwtools/tests/config/formats/test_ini.py
@@ -5,15 +5,28 @@ Tests for uwtools.config.formats.ini module.
 
 import filecmp
 
+from pytest import raises
+
 from uwtools.config.formats.ini import INIConfig
+from uwtools.exceptions import UWConfigError
 from uwtools.tests.support import fixture_path
 from uwtools.utils.file import FORMAT
 
 # Tests
 
 
-def test_format():
+def test_get_format():
     assert INIConfig.get_format() == FORMAT.ini
+
+
+def test_get_depth_threshold():
+    assert INIConfig.get_depth_threshold() == 2
+
+
+def test_instantiation_depth():
+    with raises(UWConfigError) as e:
+        INIConfig(config={1: {2: {3: 4}}})
+    assert str(e.value) == "Cannot instantiate depth-2 INIConfig with depth-3 config"
 
 
 def test_parse_include():

--- a/src/uwtools/tests/config/formats/test_nml.py
+++ b/src/uwtools/tests/config/formats/test_nml.py
@@ -5,15 +5,28 @@ Tests for uwtools.config.formats.nml module.
 
 import filecmp
 
+from pytest import raises
+
 from uwtools.config.formats.nml import NMLConfig
+from uwtools.exceptions import UWConfigError
 from uwtools.tests.support import fixture_path
 from uwtools.utils.file import FORMAT
 
 # Tests
 
 
-def test_format():
+def test_get_format():
     assert NMLConfig.get_format() == FORMAT.nml
+
+
+def test_get_depth_threshold():
+    assert NMLConfig.get_depth_threshold() == 2
+
+
+def test_instantiation_depth():
+    with raises(UWConfigError) as e:
+        NMLConfig(config={1: {2: {3: 4}}})
+    assert str(e.value) == "Cannot instantiate depth-2 NMLConfig with depth-3 config"
 
 
 def test_parse_include():

--- a/src/uwtools/tests/config/formats/test_sh.py
+++ b/src/uwtools/tests/config/formats/test_sh.py
@@ -6,15 +6,28 @@ Tests for uwtools.config.formats.sh module.
 import filecmp
 from typing import Any, Dict
 
+from pytest import raises
+
 from uwtools.config.formats.sh import SHConfig
+from uwtools.exceptions import UWConfigError
 from uwtools.tests.support import fixture_path
 from uwtools.utils.file import FORMAT
 
 # Tests
 
 
-def test_format():
+def test_get_format():
     assert SHConfig.get_format() == FORMAT.sh
+
+
+def test_get_depth_threshold():
+    assert SHConfig.get_depth_threshold() == 1
+
+
+def test_instantiation_depth():
+    with raises(UWConfigError) as e:
+        SHConfig(config={1: {2: {3: 4}}})
+    assert str(e.value) == "Cannot instantiate depth-1 SHConfig with depth-3 config"
 
 
 def test_parse_include():

--- a/src/uwtools/tests/config/formats/test_yaml.py
+++ b/src/uwtools/tests/config/formats/test_yaml.py
@@ -24,8 +24,17 @@ from uwtools.utils.file import FORMAT, _stdinproxy
 # Tests
 
 
-def test_format():
+def test_get_format():
     assert YAMLConfig.get_format() == FORMAT.yaml
+
+
+def test_get_depth_threshold():
+    assert YAMLConfig.get_depth_threshold() is None
+
+
+def test_instantiation_depth():
+    # Any depth is fine.
+    assert YAMLConfig(config={1: {2: {3: 4}}})
 
 
 def test_composite_types():

--- a/src/uwtools/tests/config/test_jinja2.py
+++ b/src/uwtools/tests/config/test_jinja2.py
@@ -334,14 +334,9 @@ class Test_Jinja2Template:
             template="{{greeting}} to {{recipient}}",
         )
 
-    def test_bad_args(self, testdata):
-        # It is an error to pass in neither a template path or a template string.
-        with raises(RuntimeError):
-            J2Template(testdata.config)
-
     def test_dump(self, testdata, tmp_path):
         path = tmp_path / "rendered.txt"
-        j2template = J2Template(testdata.config, template_str=testdata.template)
+        j2template = J2Template(values=testdata.config, template_source=testdata.template)
         j2template.dump(output_path=path)
         with open(path, "r", encoding="utf-8") as f:
             assert f.read().strip() == "Hello to the world"
@@ -350,7 +345,7 @@ class Test_Jinja2Template:
         path = tmp_path / "template.jinja2"
         with path.open("w", encoding="utf-8") as f:
             print(testdata.template, file=f)
-        validate(J2Template(testdata.config, template_path=path))
+        validate(J2Template(values=testdata.config, template_source=path))
 
     def test_render_string(self, testdata):
-        validate(J2Template(testdata.config, template_str=testdata.template))
+        validate(J2Template(values=testdata.config, template_source=testdata.template))


### PR DESCRIPTION
**Description**

Three minor updates:

1. Perform a depth check at instantiation time for `Config` objects, raising an exception if their initial depth, based on their initialization config data, is incorrect. This excludes `FieldTableConfig` and `YAMLConfig` objects, which support any depth.
2. Replace the `DEPTH` class variable in `Config` objects with an abstract static `get_depth_threshold()` method. This provides the same information, but an abstract method makes the design intent -- that this information is _required_ of all `Config` subclasses -- explicit.
3. Collapse the `template_path` and `template_string` arguments to the `J2Template` constructor into a single, overloaded `template` argument. This simplifies the interface and related instantiation logic, and follows the overloaded-argument conventions used in some of our other classes, especially `Config`.

**Type**

- [x] Code maintenance (refactoring, etc. without behavior change)
- [x] Enhancement (adds a new functionality)

**Impact**

- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.