### PR TITLE
UW-454

### DIFF
--- a/src/uwtools/config/formats/sh.py
+++ b/src/uwtools/config/formats/sh.py
@@ -1,5 +1,6 @@
 import re
 import shlex
+from io import StringIO
 from typing import Optional, Union
 
 from uwtools.config.formats.base import Config
@@ -64,10 +65,16 @@ class SHConfig(Config):
         :param cfg: The in-memory config object to dump.
         """
 
+        # Write first to a StringIO object to avoid creating a partial file in case of problems
+        # rendering or quoting config values.
+
         config_check_depths_dump(config_obj=cfg, target_format=FORMAT.sh)
+        s = StringIO()
+        for key, value in cfg.items():
+            print("%s=%s" % (key, shlex.quote(str(value))), file=s)
         with writable(path) as f:
-            for key, value in cfg.items():
-                print("%s=%s" % (key, shlex.quote(str(value))), file=f)
+            print(s.getvalue().strip(), file=f)
+        s.close()
 
     @staticmethod
     def get_depth_threshold() -> Optional[int]:

--- a/src/uwtools/config/formats/sh.py
+++ b/src/uwtools/config/formats/sh.py
@@ -67,7 +67,7 @@ class SHConfig(Config):
         config_check_depths_dump(config_obj=cfg, target_format=FORMAT.sh)
         with writable(path) as f:
             for key, value in cfg.items():
-                print(f"{key}='{value}'", file=f)
+                print("%s=%s" % (key, shlex.quote(str(value))), file=f)
 
     @staticmethod
     def get_depth_threshold() -> Optional[int]:

--- a/src/uwtools/config/formats/sh.py
+++ b/src/uwtools/config/formats/sh.py
@@ -34,7 +34,7 @@ class SHConfig(Config):
         :param config_file: Path to config file to load.
         """
         with readable(config_file) as f:
-            strings = shlex.split(f.read())
+            strings = shlex.split(f.read(), comments=True)
         d = {}
         for s in strings:
             if m := re.match(r"^([a-zA-Z_]+[a-zA-Z0-9_]*)=(.*)$", s):

--- a/src/uwtools/tests/config/formats/test_sh.py
+++ b/src/uwtools/tests/config/formats/test_sh.py
@@ -3,7 +3,6 @@
 Tests for uwtools.config.formats.sh module.
 """
 
-import filecmp
 from typing import Any, Dict
 
 from pytest import raises
@@ -41,20 +40,17 @@ def test_parse_include():
     assert len(cfgobj) == 5
 
 
-def test_sh(salad_base, tmp_path):
+def test_sh(salad_base):
     """
     Test that sh config load and dump work with a basic sh file.
     """
     infile = fixture_path("simple.sh")
-    outfile = tmp_path / "outfile.sh"
     cfgobj = SHConfig(infile)
     expected: Dict[str, Any] = {
         **salad_base["salad"],
         "how_many": "12",
     }
     assert cfgobj == expected
-    cfgobj.dump(outfile)
-    assert filecmp.cmp(infile, outfile)
     cfgobj.update({"dressing": ["ranch", "italian"]})
     expected["dressing"] = ["ranch", "italian"]
     assert cfgobj == expected

--- a/src/uwtools/tests/fixtures/include_files.sh
+++ b/src/uwtools/tests/fixtures/include_files.sh
@@ -1,3 +1,3 @@
-salad_include=!INCLUDE [./fruit_config.sh]
+salad_include="!INCLUDE [./fruit_config.sh]"
 meat=beef
 dressing=poppyseed

--- a/src/uwtools/tests/fixtures/simple.sh
+++ b/src/uwtools/tests/fixtures/simple.sh
@@ -1,3 +1,4 @@
+# comment
 base=kale
 fruit=banana
 vegetable=tomato

--- a/src/uwtools/tests/fixtures/simple.sh
+++ b/src/uwtools/tests/fixtures/simple.sh
@@ -1,6 +1,7 @@
-# comment
 base=kale
 fruit=banana
 vegetable=tomato
 how_many=12
 dressing=balsamic
+# dressing=poison -- ensure that shlex ignores comments
+echo this will be ignored, too


### PR DESCRIPTION
**Description**

Fixes a bug whereby quoted values in `.sh` files incorrectly remain quoted when rendered into templates. For example, given `template`
```
{{ greeting }}, {{ recipient }}!
```
and `values.sh`
```
greeting="Hello there"
recipient="World"
```
the old, incorrect behavior was:
```
% uw template render --input-file template --values-file values.sh
"Hello there", "World"!
```
Given the changes in this PR:
```
% uw template render --input-file template --values-file values.sh
Hello there, World!
```
The underlying issue was that Python's built-in `ConfigParser`, meant for `.ini`-style files, was being used to parse `.sh` files. Since quotes are not required in `.ini` files, `ConfigParser` can only assume that quotes are meant to be there, and so retains them as part of the parsed values.

The updates code uses Python's built-in `shlex` to parse the `.sh` file.
<!-- A summary of the change, including relevant motivation, context, useful links, etc. -->

**Type**

- [x] Bug fix (corrects a known issue)

**Impact**

- [x] This is a breaking change (changes existing functionality)

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.