### PR TITLE
Add make target to remove development environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,22 @@
 CHANNELS    = $(addprefix -c ,$(shell tr '\n' ' ' <$(RECIPE_DIR)/channels)) -c local
 METAJSON    = $(RECIPE_DIR)/meta.json
 RECIPEFILES = $(addprefix $(RECIPE_DIR)/,meta.yaml)
-TARGETS     = devshell env format lint meta package test typecheck unittest
+TARGETS     = clean-devenv devshell env format lint meta package test typecheck unittest
+
 
 export RECIPE_DIR := $(shell cd ./recipe && pwd)
 
-spec = $(call val,name)$(2)$(call val,version)$(2)$(call val,$(1))
-val  = $(shell jq -r .$(1) $(METAJSON))
+clean = $(shell $(CONDA_EXE) env remove -n DEV-$(call val,name))
+spec  = $(call val,name)$(2)$(call val,version)$(2)$(call val,$(1))
+val   = $(shell jq -r .$(1) $(METAJSON))
 
 .PHONY: $(TARGETS)
 
 all:
 	$(error Valid targets are: $(TARGETS))
+
+clean-devenv:
+	$(if $(filter DEV-$(call val,name),$(CONDA_DEFAULT_ENV)),$(error EXIT DEVSHELL FIRST),$(call clean))
 
 devshell:
 	condev-shell || true


### PR DESCRIPTION
**Description**

Add a `clean-devenv` target to the `Makefile`. If run from an active development environment (presumably in a devshell), `make clean-devenv` will remind the caller to exit their devshell first, as conda cannot remove an active environment. When run from the _base_ environment, `make clean-devenv` will remove the `DEV-uwtools` environment, after which `make devshell` will create a new environment and drop the caller into a shell with that environment active.

I'll add this to the docs on the `doc-update` branch.

**Type**

- [x] Enhancement (adds a new functionality)

**Impact**

- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.