### PR TITLE
datadep-fix

### DIFF
--- a/src/uwtools/config/validator.py
+++ b/src/uwtools/config/validator.py
@@ -30,7 +30,9 @@ def validate_yaml(
     # Collect and report on schema-validation errors.
     errors = _validation_errors(cfgobj.data, schema)
     log_method = log.error if errors else log.info
-    log_method("%s schema-validation error%s found", len(errors), "" if len(errors) == 1 else "s")
+    log_method(
+        "%s UW schema-validation error%s found", len(errors), "" if len(errors) == 1 else "s"
+    )
     for error in errors:
         for line in str(error).split("\n"):
             log.error(line)

--- a/src/uwtools/resources/rocoto.jsonschema
+++ b/src/uwtools/resources/rocoto.jsonschema
@@ -3,6 +3,9 @@
     "compoundTimeString": {
       "anyOf": [
         {
+          "type": "integer"
+        },
+        {
           "type": "string"
         },
         {

--- a/src/uwtools/resources/rocoto.jsonschema
+++ b/src/uwtools/resources/rocoto.jsonschema
@@ -195,10 +195,10 @@
       "maxProperties": 3,
       "minProperties": 2,
       "patternProperties": {
-        "^metatask(_.*)?$": {
+        "^metatask(_.+)?$": {
           "$ref": "#/$defs/metatask"
         },
-        "^task(_.*)?$": {
+        "^task_.+$": {
           "$ref": "#/$defs/task"
         }
       },
@@ -495,10 +495,10 @@
           "additionalProperties": false,
           "minProperties": 1,
           "patternProperties": {
-            "^metatask(_.*)?$": {
+            "^metatask(_.+)?$": {
               "$ref": "#/$defs/metatask"
             },
-            "^task(_.*)?$": {
+            "^task_.+$": {
               "$ref": "#/$defs/task"
             }
           },

--- a/src/uwtools/rocoto.py
+++ b/src/uwtools/rocoto.py
@@ -160,7 +160,7 @@ class _RocotoXML:
             STR.walltime,
         ):
             if tag in config:
-                SubElement(e, tag).text = config[tag]
+                SubElement(e, tag).text = str(config[tag])
         for tag in (
             STR.command,
             STR.deadline,

--- a/src/uwtools/rocoto.py
+++ b/src/uwtools/rocoto.py
@@ -33,7 +33,7 @@ def realize_rocoto_xml(
     xml = str(rxml)
     assert validate_rocoto_xml_string(xml) is True
     with writable(output_file) as f:
-        print(xml, file=f)
+        print(xml.strip(), file=f)
     return xml
 
 

--- a/src/uwtools/rocoto.py
+++ b/src/uwtools/rocoto.py
@@ -118,10 +118,12 @@ class _RocotoXML:
             e.text = config
         else:
             self._set_attrs(e, config)
-            if config := config.get(STR.cyclestr, {}):
+            if subconfig := config.get(STR.cyclestr, {}):
                 cyclestr = SubElement(e, STR.cyclestr)
-                cyclestr.text = config["value"]
-                self._set_attrs(cyclestr, config)
+                cyclestr.text = subconfig[STR.value]
+                self._set_attrs(cyclestr, subconfig)
+            elif value := config.get(STR.value, {}):
+                e.text = value
 
     def _add_metatask(self, e: Element, config: dict, taskname: str) -> None:
         """
@@ -213,7 +215,7 @@ class _RocotoXML:
         :param e: The parent element to add the new element to.
         :param config: Configuration data for this element.
         """
-        self._add_compound_time_string(e, config[STR.value], STR.datadep)
+        self._add_compound_time_string(e, config, STR.datadep)
 
     def _add_task_dependency_operand_operator(self, e: Element, config: dict) -> None:
         """

--- a/src/uwtools/rocoto.py
+++ b/src/uwtools/rocoto.py
@@ -198,13 +198,13 @@ class _RocotoXML:
         for tag, subconfig in config.items():
             tag, _ = self._tag_name(tag)
             if tag in operators:
-                self._add_task_dependency_operand_operator(e, config={tag: subconfig})
+                self._add_task_dependency_operator(e, config={tag: subconfig})
             elif tag in strequality:
                 self._add_task_dependency_strequality(e, subconfig=subconfig, tag=tag)
             elif tag == STR.datadep:
                 self._add_task_dependency_datadep(e, subconfig)
             elif tag == STR.taskdep:
-                self._add_task_dependency_operand_operator(e, config={tag: subconfig})
+                self._add_task_dependency_taskdep(e, subconfig)
             elif tag == STR.timedep:
                 self._add_task_dependency_timedep(e, subconfig)
             else:
@@ -220,9 +220,9 @@ class _RocotoXML:
         e = self._add_compound_time_string(e, config[STR.value], STR.datadep)
         self._set_attrs(e, config)
 
-    def _add_task_dependency_operand_operator(self, e: Element, config: dict) -> None:
+    def _add_task_dependency_operator(self, e: Element, config: dict) -> None:
         """
-        Add an operand or operator element to the <dependency>.
+        Add an operator element to the <dependency>.
 
         :param e: The parent element to add the new element to.
         :param config: Configuration data for this element.
@@ -231,11 +231,15 @@ class _RocotoXML:
         for tag, subconfig in config.items():
             tag, _ = self._tag_name(tag)
             if tag in operators:
-                self._add_task_dependency_operand_operator(SubElement(e, tag), config=subconfig)
+                self._add_task_dependency_operator(SubElement(e, tag), config=subconfig)
             elif tag in strequality:
                 self._add_task_dependency_strequality(e, subconfig=subconfig, tag=tag)
+            elif tag == STR.datadep:
+                self._add_task_dependency_datadep(e, subconfig)
             elif tag == STR.taskdep:
-                self._set_attrs(SubElement(e, tag), subconfig)
+                self._add_task_dependency_taskdep(e, subconfig)
+            elif tag == STR.timedep:
+                self._add_task_dependency_timedep(e, subconfig)
             else:
                 raise UWConfigError("Unhandled dependency type %s" % tag)
 
@@ -246,6 +250,15 @@ class _RocotoXML:
         :param tag: Name of new element to add.
         """
         self._set_attrs(SubElement(e, tag), subconfig)
+
+    def _add_task_dependency_taskdep(self, e: Element, config: dict) -> None:
+        """
+        Add a <taskdep> element to the <dependency>.
+
+        :param e: The parent element to add the new element to.
+        :param config: Configuration data for this element.
+        """
+        self._set_attrs(SubElement(e, STR.taskdep), config)
 
     def _add_task_dependency_timedep(self, e: Element, config: dict) -> None:
         """

--- a/src/uwtools/rocoto.py
+++ b/src/uwtools/rocoto.py
@@ -151,8 +151,7 @@ class _RocotoXML:
         :param config: Configuration data for this element.
         :param taskname: The name of the task being defined.
         """
-        kwargs = {"name": taskname} if taskname else {}
-        e = SubElement(e, STR.task, **kwargs)
+        e = SubElement(e, STR.task, name=taskname)
         self._set_attrs(e, config)
         self._set_and_render_jobname(config, taskname)
         for tag in (

--- a/src/uwtools/rocoto.py
+++ b/src/uwtools/rocoto.py
@@ -105,13 +105,14 @@ class _RocotoXML:
         with writable(path) as f:
             f.write(str(self).strip())
 
-    def _add_compound_time_string(self, e: Element, config: dict, tag: str) -> None:
+    def _add_compound_time_string(self, e: Element, config: dict, tag: str) -> Element:
         """
         Add to the given element a child element possibly containing a <cyclestr>.
 
         :param e: The element to add the child element to.
         :param config: Configuration data for the child element.
         :param tag: Name of child element to add.
+        :return: The child element.
         """
         e = SubElement(e, tag)
         if isinstance(config, str):
@@ -122,8 +123,7 @@ class _RocotoXML:
                 cyclestr = SubElement(e, STR.cyclestr)
                 cyclestr.text = subconfig[STR.value]
                 self._set_attrs(cyclestr, subconfig)
-            elif value := config.get(STR.value, {}):
-                e.text = value
+        return e
 
     def _add_metatask(self, e: Element, config: dict, taskname: str) -> None:
         """
@@ -215,7 +215,8 @@ class _RocotoXML:
         :param e: The parent element to add the new element to.
         :param config: Configuration data for this element.
         """
-        self._add_compound_time_string(e, config, STR.datadep)
+        e = self._add_compound_time_string(e, config[STR.value], STR.datadep)
+        self._set_attrs(e, config)
 
     def _add_task_dependency_operand_operator(self, e: Element, config: dict) -> None:
         """

--- a/src/uwtools/rocoto.py
+++ b/src/uwtools/rocoto.py
@@ -234,12 +234,8 @@ class _RocotoXML:
                 self._add_task_dependency_operand_operator(SubElement(e, tag), config=subconfig)
             elif tag in strequality:
                 self._add_task_dependency_strequality(e, subconfig=subconfig, tag=tag)
-            elif tag == STR.datadep:
-                self._add_compound_time_string(e, config[tag], tag)
             elif tag == STR.taskdep:
                 self._set_attrs(SubElement(e, tag), subconfig)
-            elif tag == STR.timedep:
-                self._add_compound_time_string(e, config[tag], tag)
             else:
                 raise UWConfigError("Unhandled dependency type %s" % tag)
 

--- a/src/uwtools/tests/config/test_validator.py
+++ b/src/uwtools/tests/config/test_validator.py
@@ -123,7 +123,7 @@ def test_validate_yaml_fail_bad_enum_val(assets, caplog):
     schema_file, _, cfgobj = assets
     cfgobj["color"] = "yellow"  # invalid enum value
     assert not validator.validate_yaml(schema_file=schema_file, config=cfgobj)
-    assert any(x for x in caplog.records if "1 schema-validation error found" in x.message)
+    assert any(x for x in caplog.records if "1 UW schema-validation error found" in x.message)
     assert any(x for x in caplog.records if "'yellow' is not one of" in x.message)
 
 
@@ -132,7 +132,7 @@ def test_validate_yaml_fail_bad_number_val(assets, caplog):
     schema_file, _, cfgobj = assets
     cfgobj["number"] = "string"  # invalid number value
     assert not validator.validate_yaml(schema_file=schema_file, config=cfgobj)
-    assert any(x for x in caplog.records if "1 schema-validation error found" in x.message)
+    assert any(x for x in caplog.records if "1 UW schema-validation error found" in x.message)
     assert any(x for x in caplog.records if "'string' is not of type 'number'" in x.message)
 
 

--- a/src/uwtools/tests/drivers/test_driver.py
+++ b/src/uwtools/tests/drivers/test_driver.py
@@ -97,6 +97,6 @@ def test_validation(caplog, configs, schema, tmp_path, valid):
         log.setLevel(logging.INFO)
         ConcreteDriver(config_file=config_file)
         if valid:
-            assert logged(caplog, "0 schema-validation errors found")
+            assert logged(caplog, "0 UW schema-validation errors found")
         else:
-            assert logged(caplog, "2 schema-validation errors found")
+            assert logged(caplog, "2 UW schema-validation errors found")

--- a/src/uwtools/tests/test_rocoto.py
+++ b/src/uwtools/tests/test_rocoto.py
@@ -182,13 +182,13 @@ class Test__RocotoXML:
         instance._add_task(e=root, config=config, taskname="foo")
 
     def test__add_task_dependency_and(self, instance, root):
-        config = {"and": {"or_get_obs": {"taskdep": {"attrs": {"age": "120"}}}}}
+        config = {"and": {"or_get_obs": {"taskdep": {"attrs": {"task": "foo"}}}}}
         instance._add_task_dependency(e=root, config=config)
         dependency = root[0]
         assert dependency.tag == "dependency"
         and_ = dependency[0]
         assert and_.tag == "and"
-        assert and_.getchildren()[0].getchildren()[0].get("age") == "120"
+        assert and_.xpath("or[1]/taskdep")[0].get("task") == "foo"
 
     @pytest.mark.parametrize(
         "value",

--- a/src/uwtools/tests/test_rocoto.py
+++ b/src/uwtools/tests/test_rocoto.py
@@ -190,7 +190,10 @@ class Test__RocotoXML:
         assert and_.tag == "and"
         assert and_.getchildren()[0].getchildren()[0].get("age") == "120"
 
-    @pytest.mark.parametrize("value", ["/some/file", {"cyclestr": {"value": "@Y@m@d@H", "attrs": {"offset": "06:00:00"}}}])
+    @pytest.mark.parametrize(
+        "value",
+        ["/some/file", {"cyclestr": {"value": "@Y@m@d@H", "attrs": {"offset": "06:00:00"}}}],
+    )
     def test__add_task_dependency_datadep(self, instance, root, value):
         age = "00:00:02:00"
         minsize = "1K"
@@ -402,8 +405,6 @@ def test_schema_compoundTimeString():
     errors = validator("$defs", "compoundTimeString")
     # Just a string is ok:
     assert not errors("foo")
-    # Non-string types are not ok:
-    assert "88 is not valid" in errors(88)
     # A simple cycle string is ok:
     assert not errors({"cyclestr": {"value": "@Y@m@d@H"}})
     # The "value" entry is required:

--- a/src/uwtools/tests/test_rocoto.py
+++ b/src/uwtools/tests/test_rocoto.py
@@ -212,7 +212,7 @@ class Test__RocotoXML:
         with raises(UWConfigError):
             instance._add_task_dependency(e=root, config=config)
 
-    def test__add_task_dependency_operand_fail(self, instance, root):
+    def test__add_task_dependency_fail_bad_operand(self, instance, root):
         config = {"and": {"unrecognized": "whatever"}}
         with raises(UWConfigError):
             instance._add_task_dependency(e=root, config=config)
@@ -222,9 +222,33 @@ class Test__RocotoXML:
         [{"and": {"strneq": {"attrs": {"left": "&RUN_GSI;", "right": "YES"}}}}],
     )
     def test__add_task_dependency_operator(self, config, instance, root):
-        instance._add_task_dependency_operand_operator(e=root, config=config)
+        instance._add_task_dependency_operator(e=root, config=config)
         for tag, _ in config.items():
             assert tag == next(iter(config))
+
+    def test__add_task_dependency_operator_datadep_operand(self, instance, root):
+        value = "/some/file"
+        config = {"datadep": {"value" : value}}
+        instance._add_task_dependency_operator(e=root, config=config)
+        e = root[0]
+        assert e.tag == "datadep"
+        assert e.text == value
+
+    def test__add_task_dependency_operator_task_operand(self, instance, root):
+        taskname = "some-task"
+        config = {"taskdep": {"attrs": {"task": taskname}}}
+        instance._add_task_dependency_operator(e=root, config=config)
+        e = root[0]
+        assert e.tag == "taskdep"
+        assert e.get("task") == taskname
+
+    def test__add_task_dependency_operator_timedep_operand(self, instance, root):
+        value = 20230103120000
+        config = {"timedep": value}
+        instance._add_task_dependency_operator(e=root, config=config)
+        e = root[0]
+        assert e.tag == "timedep"
+        assert e.text == str(value)
 
     def test__add_task_dependency_streq(self, instance, root):
         config = {"streq": {"attrs": {"left": "&RUN_GSI;", "right": "YES"}}}

--- a/src/uwtools/tests/test_rocoto.py
+++ b/src/uwtools/tests/test_rocoto.py
@@ -177,6 +177,12 @@ class Test__RocotoXML:
         mocks["_add_task_dependency"].assert_called_once_with(task, "qux")
         mocks["_add_task_envar"].assert_called_once_with(task, "A", "apple")
 
+    @pytest.mark.parametrize("cores", [1, "1"])
+    def test__add_task_cores_int_or_str(self, cores, instance, root):
+        # Ensure that either int or str "cores" values are accepted.
+        config = {"command": "c", "cores": cores, "walltime": "00:00:01"}
+        instance._add_task(e=root, config=config, taskname="foo")
+
     def test__add_task_dependency(self, instance, root):
         config = {"taskdep": {"attrs": {"task": "foo"}}}
         instance._add_task_dependency(e=root, config=config)

--- a/src/uwtools/tests/test_rocoto.py
+++ b/src/uwtools/tests/test_rocoto.py
@@ -217,38 +217,38 @@ class Test__RocotoXML:
         with raises(UWConfigError):
             instance._add_task_dependency(e=root, config=config)
 
-    @pytest.mark.parametrize(
-        "config",
-        [{"and": {"strneq": {"attrs": {"left": "&RUN_GSI;", "right": "YES"}}}}],
-    )
-    def test__add_task_dependency_operator(self, config, instance, root):
-        instance._add_task_dependency_operator(e=root, config=config)
-        for tag, _ in config.items():
-            assert tag == next(iter(config))
+    # @pytest.mark.parametrize(
+    #     "config",
+    #     [{"and": {"strneq": {"attrs": {"left": "&RUN_GSI;", "right": "YES"}}}}],
+    # )
+    # def test__add_task_dependency_operator(self, config, instance, root):
+    #     instance._add_task_dependency_operator(e=root, config=config)
+    #     for tag, _ in config.items():
+    #         assert tag == next(iter(config))
 
-    def test__add_task_dependency_operator_datadep_operand(self, instance, root):
-        value = "/some/file"
-        config = {"datadep": {"value": value}}
-        instance._add_task_dependency_operator(e=root, config=config)
-        e = root[0]
-        assert e.tag == "datadep"
-        assert e.text == value
+    # def test__add_task_dependency_operator_datadep_operand(self, instance, root):
+    #     value = "/some/file"
+    #     config = {"datadep": {"value": value}}
+    #     instance._add_task_dependency_operator(e=root, config=config)
+    #     e = root[0]
+    #     assert e.tag == "datadep"
+    #     assert e.text == value
 
-    def test__add_task_dependency_operator_task_operand(self, instance, root):
-        taskname = "some-task"
-        config = {"taskdep": {"attrs": {"task": taskname}}}
-        instance._add_task_dependency_operator(e=root, config=config)
-        e = root[0]
-        assert e.tag == "taskdep"
-        assert e.get("task") == taskname
+    # def test__add_task_dependency_operator_task_operand(self, instance, root):
+    #     taskname = "some-task"
+    #     config = {"taskdep": {"attrs": {"task": taskname}}}
+    #     instance._add_task_dependency_operator(e=root, config=config)
+    #     e = root[0]
+    #     assert e.tag == "taskdep"
+    #     assert e.get("task") == taskname
 
-    def test__add_task_dependency_operator_timedep_operand(self, instance, root):
-        value = 20230103120000
-        config = {"timedep": value}
-        instance._add_task_dependency_operator(e=root, config=config)
-        e = root[0]
-        assert e.tag == "timedep"
-        assert e.text == str(value)
+    # def test__add_task_dependency_operator_timedep_operand(self, instance, root):
+    #     value = 20230103120000
+    #     config = {"timedep": value}
+    #     instance._add_task_dependency_operator(e=root, config=config)
+    #     e = root[0]
+    #     assert e.tag == "timedep"
+    #     assert e.text == str(value)
 
     def test__add_task_dependency_streq(self, instance, root):
         config = {"streq": {"attrs": {"left": "&RUN_GSI;", "right": "YES"}}}
@@ -267,11 +267,11 @@ class Test__RocotoXML:
         ],
     )
     def test__add_task_dependency_strequality(self, config, instance, root):
-        tag, subconfig = config
-        instance._add_task_dependency_strequality(e=root, subconfig=subconfig, tag=tag)
+        tag, config = config
+        instance._add_task_dependency_strequality(e=root, config=config, tag=tag)
         element = root[0]
         assert tag == element.tag
-        for attr, val in subconfig["attrs"].items():
+        for attr, val in config["attrs"].items():
             assert element.get(attr) == val
 
     def test__add_task_dependency_taskdep(self, instance, root):

--- a/src/uwtools/tests/test_rocoto.py
+++ b/src/uwtools/tests/test_rocoto.py
@@ -228,7 +228,7 @@ class Test__RocotoXML:
 
     def test__add_task_dependency_operator_datadep_operand(self, instance, root):
         value = "/some/file"
-        config = {"datadep": {"value" : value}}
+        config = {"datadep": {"value": value}}
         instance._add_task_dependency_operator(e=root, config=config)
         e = root[0]
         assert e.tag == "datadep"

--- a/src/uwtools/tests/test_rocoto.py
+++ b/src/uwtools/tests/test_rocoto.py
@@ -190,10 +190,10 @@ class Test__RocotoXML:
         assert and_.tag == "and"
         assert and_.getchildren()[0].getchildren()[0].get("age") == "120"
 
-    def test__add_task_dependency_datadep(self, instance, root):
+    @pytest.mark.parametrize("value", ["/some/file", {"cyclestr": {"value": "@Y@m@d@H", "attrs": {"offset": "06:00:00"}}}])
+    def test__add_task_dependency_datadep(self, instance, root, value):
         age = "00:00:02:00"
         minsize = "1K"
-        value = "/some/file"
         config = {"datadep": {"attrs": {"age": age, "minsize": minsize}, "value": value}}
         instance._add_task_dependency(e=root, config=config)
         dependency = root[0]
@@ -202,7 +202,7 @@ class Test__RocotoXML:
         assert child.tag == "datadep"
         assert child.get("age") == age
         assert child.get("minsize") == minsize
-        assert child.text == value
+        assert child.text == value if isinstance(value, str) else value["cyclestr"]["value"]
 
     def test__add_task_dependency_fail(self, instance, root):
         config = {"unrecognized": "whatever"}

--- a/src/uwtools/tests/test_rocoto.py
+++ b/src/uwtools/tests/test_rocoto.py
@@ -181,15 +181,6 @@ class Test__RocotoXML:
         config = {"command": "c", "cores": cores, "walltime": "00:00:01"}
         instance._add_task(e=root, config=config, taskname="foo")
 
-    def test__add_task_dependency(self, instance, root):
-        config = {"taskdep": {"attrs": {"task": "foo"}}}
-        instance._add_task_dependency(e=root, config=config)
-        dependency = root[0]
-        assert dependency.tag == "dependency"
-        taskdep = dependency[0]
-        assert taskdep.tag == "taskdep"
-        assert taskdep.get("task") == "foo"
-
     def test__add_task_dependency_and(self, instance, root):
         config = {"and": {"or_get_obs": {"taskdep": {"attrs": {"age": "120"}}}}}
         instance._add_task_dependency(e=root, config=config)
@@ -198,6 +189,20 @@ class Test__RocotoXML:
         and_ = dependency[0]
         assert and_.tag == "and"
         assert and_.getchildren()[0].getchildren()[0].get("age") == "120"
+
+    def test__add_task_dependency_datadep(self, instance, root):
+        age = "00:00:02:00"
+        minsize = "1K"
+        value = "/some/file"
+        config = {"datadep": {"attrs": {"age": age, "minsize": minsize}, "value": value}}
+        instance._add_task_dependency(e=root, config=config)
+        dependency = root[0]
+        assert dependency.tag == "dependency"
+        child = dependency[0]
+        assert child.tag == "datadep"
+        assert child.get("age") == age
+        assert child.get("minsize") == minsize
+        assert child.text == value
 
     def test__add_task_dependency_fail(self, instance, root):
         config = {"unrecognized": "whatever"}
@@ -253,6 +258,15 @@ class Test__RocotoXML:
         assert tag == element.tag
         for attr, val in subconfig["attrs"].items():
             assert element.get(attr) == val
+
+    def test__add_task_dependency_taskdep(self, instance, root):
+        config = {"taskdep": {"attrs": {"task": "foo"}}}
+        instance._add_task_dependency(e=root, config=config)
+        dependency = root[0]
+        assert dependency.tag == "dependency"
+        child = dependency[0]
+        assert child.tag == "taskdep"
+        assert child.get("task") == "foo"
 
     def test__config_validate_config(self, assets, instance):
         cfgfile, _ = assets

--- a/src/uwtools/tests/test_rocoto.py
+++ b/src/uwtools/tests/test_rocoto.py
@@ -130,16 +130,14 @@ class Test__RocotoXML:
         assert rocoto._RocotoXML(config=YAMLConfig(cfgfile))._root.tag == "workflow"
 
     def test__add_compound_time_string_basic(self, instance, root):
-        config = {"foo": "bar"}
+        config = "bar"
         instance._add_compound_time_string(e=root, config=config, tag="foo")
         child = root[0]
         assert child.tag == "foo"
         assert child.text == "bar"
 
     def test__add_compound_time_string_cyclestr(self, instance, root):
-        config = {
-            "foo": {"attrs": {"bar": "88"}, "cyclestr": {"attrs": {"baz": "99"}, "value": "qux"}}
-        }
+        config = {"attrs": {"bar": "88"}, "cyclestr": {"attrs": {"baz": "99"}, "value": "qux"}}
         instance._add_compound_time_string(e=root, config=config, tag="foo")
         child = root[0]
         assert child.get("bar") == "88"
@@ -193,7 +191,7 @@ class Test__RocotoXML:
         assert taskdep.get("task") == "foo"
 
     def test__add_task_dependency_and(self, instance, root):
-        config = {"and": {"or_get_obs": {"datadep": {"attrs": {"age": "120"}}}}}
+        config = {"and": {"or_get_obs": {"taskdep": {"attrs": {"age": "120"}}}}}
         instance._add_task_dependency(e=root, config=config)
         dependency = root[0]
         assert dependency.tag == "dependency"
@@ -208,7 +206,7 @@ class Test__RocotoXML:
 
     @pytest.mark.parametrize(
         "config",
-        [{"datadep": {"attrs": {"age": "120"}}}, {"timedep": {"attrs": {"offset": "&DEADLINE;"}}}],
+        [{"timedep": {"attrs": {"offset": "&DEADLINE;"}}}],
     )
     def test__add_task_dependency_operand(self, config, instance, root):
         instance._add_task_dependency_operand_operator(e=root, config=config)
@@ -225,10 +223,7 @@ class Test__RocotoXML:
 
     @pytest.mark.parametrize(
         "config",
-        [
-            {"and": {"or": {"datadep": {"attrs": {"age": "120"}}}}},
-            {"and": {"strneq": {"attrs": {"left": "&RUN_GSI;", "right": "YES"}}}},
-        ],
+        [{"and": {"strneq": {"attrs": {"left": "&RUN_GSI;", "right": "YES"}}}}],
     )
     def test__add_task_dependency_operator(self, config, instance, root):
         instance._add_task_dependency_operand_operator(e=root, config=config)

--- a/src/uwtools/tests/test_rocoto.py
+++ b/src/uwtools/tests/test_rocoto.py
@@ -14,7 +14,7 @@ from pytest import fixture, raises
 from uwtools import rocoto
 from uwtools.config.formats.yaml import YAMLConfig
 from uwtools.config.validator import _validation_errors
-from uwtools.exceptions import UWConfigError
+from uwtools.exceptions import UWConfigError, UWError
 from uwtools.tests.support import fixture_path
 from uwtools.utils.file import resource_pathobj
 
@@ -59,7 +59,7 @@ def test_realize_rocoto_invalid_xml(assets):
     cfgfile, outfile = assets
     with patch.object(rocoto, "validate_rocoto_xml_string") as vrxs:
         vrxs.return_value = False
-        with raises(AssertionError):
+        with raises(UWError):
             rocoto.realize_rocoto_xml(config=cfgfile, output_file=outfile)
 
 

--- a/src/uwtools/tests/test_rocoto.py
+++ b/src/uwtools/tests/test_rocoto.py
@@ -217,38 +217,39 @@ class Test__RocotoXML:
         with raises(UWConfigError):
             instance._add_task_dependency(e=root, config=config)
 
-    # @pytest.mark.parametrize(
-    #     "config",
-    #     [{"and": {"strneq": {"attrs": {"left": "&RUN_GSI;", "right": "YES"}}}}],
-    # )
-    # def test__add_task_dependency_operator(self, config, instance, root):
-    #     instance._add_task_dependency_operator(e=root, config=config)
-    #     for tag, _ in config.items():
-    #         assert tag == next(iter(config))
+    @pytest.mark.parametrize(
+        "tag_config",
+        [("and", {"strneq": {"attrs": {"left": "&RUN_GSI;", "right": "YES"}}})],
+    )
+    def test__add_task_dependency_operator(self, instance, root, tag_config):
+        tag, config = tag_config
+        instance._add_task_dependency_child(e=root, config=config, tag=tag)
+        for tag, _ in config.items():
+            assert tag == next(iter(config))
 
-    # def test__add_task_dependency_operator_datadep_operand(self, instance, root):
-    #     value = "/some/file"
-    #     config = {"datadep": {"value": value}}
-    #     instance._add_task_dependency_operator(e=root, config=config)
-    #     e = root[0]
-    #     assert e.tag == "datadep"
-    #     assert e.text == value
+    def test__add_task_dependency_operator_datadep_operand(self, instance, root):
+        value = "/some/file"
+        config = {"value": value}
+        instance._add_task_dependency_child(e=root, config=config, tag="datadep")
+        e = root[0]
+        assert e.tag == "datadep"
+        assert e.text == value
 
-    # def test__add_task_dependency_operator_task_operand(self, instance, root):
-    #     taskname = "some-task"
-    #     config = {"taskdep": {"attrs": {"task": taskname}}}
-    #     instance._add_task_dependency_operator(e=root, config=config)
-    #     e = root[0]
-    #     assert e.tag == "taskdep"
-    #     assert e.get("task") == taskname
+    def test__add_task_dependency_operator_task_operand(self, instance, root):
+        taskname = "some-task"
+        config = {"attrs": {"task": taskname}}
+        instance._add_task_dependency_child(e=root, config=config, tag="taskdep")
+        e = root[0]
+        assert e.tag == "taskdep"
+        assert e.get("task") == taskname
 
-    # def test__add_task_dependency_operator_timedep_operand(self, instance, root):
-    #     value = 20230103120000
-    #     config = {"timedep": value}
-    #     instance._add_task_dependency_operator(e=root, config=config)
-    #     e = root[0]
-    #     assert e.tag == "timedep"
-    #     assert e.text == str(value)
+    def test__add_task_dependency_operator_timedep_operand(self, instance, root):
+        value = 20230103120000
+        config = value
+        instance._add_task_dependency_child(e=root, config=config, tag="timedep")
+        e = root[0]
+        assert e.tag == "timedep"
+        assert e.text == str(value)
 
     def test__add_task_dependency_streq(self, instance, root):
         config = {"streq": {"attrs": {"left": "&RUN_GSI;", "right": "YES"}}}


### PR DESCRIPTION
**Description**

- Fix handling of the Rocoto `<datadep>` and `<timedep>` dependency tags.
- Improve error reporting when Rocoto XML validation fails.

**Type**

- [x] Bug fix (corrects a known issue)
- [x] Enhancement (adds a new functionality)
- [x] Tooling (CI, code-quality, packaging, revision-control, etc.)

**Impact**

- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
