### PR TITLE
Fixing CLI config validate

### DIFF
--- a/src/uwtools/cli.py
+++ b/src/uwtools/cli.py
@@ -160,7 +160,7 @@ def _add_subparser_config_validate(subparsers: Subparsers) -> SubmodeChecks:
     required = parser.add_argument_group(TITLE_REQ_ARG)
     _add_arg_schema_file(required)
     optional = _basic_setup(parser)
-    _add_arg_config_file(optional)
+    _add_arg_input_file(optional)
     return _add_args_quiet_and_verbose(optional)
 
 
@@ -230,7 +230,7 @@ def _dispatch_config_validate(args: Args) -> bool:
 
     :param args: Parsed command-line args.
     """
-    return uwtools.api.config.validate(schema_file=args[STR.schemafile], config=args[STR.config])
+    return uwtools.api.config.validate(schema_file=args[STR.schemafile], config=args[STR.infile])
 
 
 # Mode forecast

--- a/src/uwtools/cli.py
+++ b/src/uwtools/cli.py
@@ -160,7 +160,7 @@ def _add_subparser_config_validate(subparsers: Subparsers) -> SubmodeChecks:
     required = parser.add_argument_group(TITLE_REQ_ARG)
     _add_arg_schema_file(required)
     optional = _basic_setup(parser)
-    _add_arg_input_file(optional)
+    _add_arg_config_file(optional)
     return _add_args_quiet_and_verbose(optional)
 
 

--- a/src/uwtools/tests/test_cli.py
+++ b/src/uwtools/tests/test_cli.py
@@ -289,10 +289,11 @@ def test__dispatch_config_translate_unsupported():
 
 def test__dispatch_config_validate_config_obj():
     config = uwtools.api.config._YAMLConfig(config={})
-    args = {STR.schemafile: 1, STR.infile: config}
+    _dispatch_config_validate_args = {STR.schemafile: 1, STR.infile: config}
     with patch.object(uwtools.api.config, "_validate_yaml") as _validate_yaml:
-        cli._dispatch_config_validate(args)
-    _validate_yaml.assert_called_once_with(**args)
+        cli._dispatch_config_validate(_dispatch_config_validate_args)
+    _validate_yaml_args = {STR.schemafile: 1, STR.config: config}
+    _validate_yaml.assert_called_once_with(**_validate_yaml_args)
 
 
 @pytest.mark.parametrize("params", [(STR.run, "_dispatch_forecast_run")])

--- a/src/uwtools/tests/test_cli.py
+++ b/src/uwtools/tests/test_cli.py
@@ -287,7 +287,7 @@ def test__dispatch_config_translate_unsupported():
     assert cli._dispatch_config_translate(args) is False
 
 
-def test__dispath_config_validate_config_obj():
+def test__dispatch_config_validate_config_obj():
     config = uwtools.api.config._YAMLConfig(config={})
     args = {STR.schemafile: 1, STR.config: config}
     with patch.object(uwtools.api.config, "_validate_yaml") as _validate_yaml:

--- a/src/uwtools/tests/test_cli.py
+++ b/src/uwtools/tests/test_cli.py
@@ -289,7 +289,7 @@ def test__dispatch_config_translate_unsupported():
 
 def test__dispatch_config_validate_config_obj():
     config = uwtools.api.config._YAMLConfig(config={})
-    args = {STR.schemafile: 1, STR.config: config}
+    args = {STR.schemafile: 1, STR.infile: config}
     with patch.object(uwtools.api.config, "_validate_yaml") as _validate_yaml:
         cli._dispatch_config_validate(args)
     _validate_yaml.assert_called_once_with(**args)


### PR DESCRIPTION
**Description**

In documenting the config CLI, it became apparent that the `config validate` function was not working as expected. The subparser entry added an 'input_file' while the dispatch was looking for STR.config. As the API looks for 'config', the simplest fix was to change the subparser to 'config'.

**Type**

Select one or more:

- [x] Bug fix (corrects a known issue)

**Impact**

- [ ] This is a non-breaking change (existing functionality continues to work as expected)
- [ ] This is a breaking change (changes existing functionality)

**Checklist**

Affirm:

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
